### PR TITLE
Release/421 release candidate

### DIFF
--- a/johnsnowlabs/__init__.py
+++ b/johnsnowlabs/__init__.py
@@ -2,13 +2,29 @@ from .auto_install.health_checks.report import check_health, list_remote_license
 from .utils.sparksession_utils import start
 from .auto_install.install_flow import install
 # get helpers into global space
-from johnsnowlabs import medical, nlp, ocr, settings, viz, finance, legal
+from johnsnowlabs import nlp, settings, viz
 import johnsnowlabs as jsl
 
 # databricks
 from johnsnowlabs.auto_install.databricks.work_utils import run_in_databricks
 from johnsnowlabs.nlp import *
 
+
+# These we may only import, if the corresponding package is installed
+# Otherwise we will run modules __init__ to early and will not attach new classes/methods to it
+if try_import_lib('sparknlp_jsl') and try_import_lib('sparknlp'):
+    from johnsnowlabs import medical,finance,legal
+
+if try_import_lib('sparkocr') and try_import_lib('sparknlp'):
+    from johnsnowlabs import ocr
+
+
+
+
+
+def refresh_imports():
+    import inspect
+    inspect.__globals__
 
 def new_version_online():
     from .utils.pip_utils import get_latest_lib_version_on_pypi

--- a/johnsnowlabs/abstract_base/software_product.py
+++ b/johnsnowlabs/abstract_base/software_product.py
@@ -32,6 +32,7 @@ class AbstractSoftwareProduct(ABC):
     py_module_name: Optional[str] = None
     pypi_name: Optional[str] = None
     # Only defined for JSL libs below
+    install_deps: Optional[bool] = True
     compatible_spark_versions: List[SparkVersion]
     latest_version: Optional[LibVersion] = None
     jsl_url_resolver: Optional[Py4JJslLibDependencyResolverABC] = None
@@ -132,6 +133,8 @@ class AbstractSoftwareProduct(ABC):
 
         -m pip download <module> -d path
         """
+        if not cls.install_deps:
+            include_dependencies = False
         if not version and cls.latest_version:
             version = cls.latest_version
         if cls.pypi_name:

--- a/johnsnowlabs/auto_install/install_software.py
+++ b/johnsnowlabs/auto_install/install_software.py
@@ -172,8 +172,10 @@ def check_and_install_dependencies(product: AbstractSoftwareProduct,
             else:
                 print(f'{installed_software.logo} {installed_software.name} not installed! ❌')
 
-        print(
-            f'🔁{Fore.LIGHTRED_EX} If you are on Google Colab, please restart your Notebook for changes to take effect {Fore.RESET}🔁')
+        # Trigger Imports after install. so module is reloaded and no re-start is required
+        from johnsnowlabs import medical, finance, legal, ocr
+        # print(f'🔁{Fore.LIGHTRED_EX} If you are on Google Colab, please restart your Notebook for changes to take effect {Fore.RESET}🔁')
+
     else:
         print(f'👌 Everything is already installed, no changes made')
 

--- a/johnsnowlabs/auto_install/softwares.py
+++ b/johnsnowlabs/auto_install/softwares.py
@@ -143,6 +143,7 @@ class NluSoftware(AbstractSoftwareProduct):
     latest_version = LatestCompatibleProductVersion.nlu.value
     py_module_name = 'nlu'
     pypi_name = 'nlu'
+    install_deps = False
 
     @classmethod
     def get_installed_version_via_import(cls):

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -2,7 +2,7 @@ from os.path import expanduser
 import os
 
 # libs, these versions are used for auto-installs and version  checks
-raw_version_jsl_lib = '4.2.0'
+raw_version_jsl_lib = '4.2.1rc1'
 raw_version_nlp = '4.2.0'
 raw_version_medical = '4.2.0'
 raw_version_secret_medical = '4.2.0'

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -2,7 +2,7 @@ from os.path import expanduser
 import os
 
 # libs, these versions are used for auto-installs and version  checks
-raw_version_jsl_lib = '4.2.1rc1'
+raw_version_jsl_lib = '4.2.1'
 raw_version_nlp = '4.2.0'
 raw_version_medical = '4.2.0'
 raw_version_secret_medical = '4.2.0'


### PR DESCRIPTION
- No more restarts required after running `jsl.install()`
- extended underlying Software Node abstraction to be configurable to not install deps via pip. Handy for dependency conflicts.