### PR TITLE
Added encoding to open calls

### DIFF
--- a/johnsnowlabs/abstract_base/pydantic_model.py
+++ b/johnsnowlabs/abstract_base/pydantic_model.py
@@ -16,7 +16,7 @@ BaseConfig.json_encoders = {
 class WritableBaseModel(BaseModel):
 
     def write(self, path, *args, **kwargs):
-        with open(path, 'w') as json_file:
+        with open(path, 'w', encoding="utf8") as json_file:
             if 'indent' not in kwargs:
                 kwargs['indent'] = settings.json_indent
             json_file.write(self.json(*args, **kwargs))

--- a/johnsnowlabs/abstract_base/software_product.py
+++ b/johnsnowlabs/abstract_base/software_product.py
@@ -144,7 +144,7 @@ class AbstractSoftwareProduct(ABC):
                 # Unless we toggle enforce_versions=False
                 suite = get_install_suite_from_jsl_home()
                 if cls.name == ProductName.hc.value and suite.hc and suite.hc.py_lib:
-                    return install_standard_pypi_lib(f'{settings.py_dir}/{suite.hc.py_lib.file_name}',
+                    return install_standard_pypi_lib(os.path.join(settings.py_dir, suite.hc.py_lib.file_name),
                                                      cls.py_module_name,
                                                      python_path=py_path, upgrade=upgrade, re_install=re_install,
                                                      # version=version,
@@ -152,14 +152,14 @@ class AbstractSoftwareProduct(ABC):
                                                      include_dependencies=include_dependencies,
                                                      )
                 elif cls.name == ProductName.ocr.value and suite.ocr and suite.ocr.py_lib:
-                    return install_standard_pypi_lib(f'{settings.py_dir}/{suite.ocr.py_lib.file_name}',
+                    return install_standard_pypi_lib(os.path.join(settings.py_dir, suite.ocr.py_lib.file_name),
                                                      cls.py_module_name,
                                                      python_path=py_path, upgrade=upgrade, re_install=re_install,
                                                      # version=version,
                                                      download_folder=download_folder,
                                                      include_dependencies=include_dependencies, )
                 elif cls.name == ProductName.nlp.value and suite.nlp and suite.nlp.py_lib:
-                    return install_standard_pypi_lib(f'{settings.py_dir}/{suite.nlp.py_lib.file_name}',
+                    return install_standard_pypi_lib(os.path.join(settings.py_dir, suite.nlp.py_lib.file_name),
                                                      cls.py_module_name,
                                                      python_path=py_path, upgrade=upgrade, re_install=re_install,
                                                      # version=version,

--- a/johnsnowlabs/py_models/jsl_secrets.py
+++ b/johnsnowlabs/py_models/jsl_secrets.py
@@ -478,13 +478,13 @@ class JslSecrets(WritableBaseModel):
         for license_file in os.listdir(settings.license_dir):
             if license_file == 'info.json':
                 continue
-            secrets = JslSecrets.parse_file(f'{settings.license_dir}/{license_file}')
+            secrets = JslSecrets.parse_file(os.path.join(settings.license_dir, license_file))
             if secrets.HC_SECRET and hc_secrets and \
                     JslSecrets.is_other_older_secret(hc_secrets, secrets.HC_SECRET):
-                invalid_licenses.append(f'{settings.license_dir}/{license_file}')
+                invalid_licenses.append(os.path.join(settings.license_dir, license_file))
             elif secrets.OCR_SECRET and ocr_secret \
                     and JslSecrets.is_other_older_secret(ocr_secret, secrets.OCR_SECRET):
-                invalid_licenses.append(f'{settings.license_dir}/{license_file}')
+                invalid_licenses.append(os.path.join(settings.license_dir, license_file))
 
         for license_path in invalid_licenses:
             print(f'Updating license file {license_path}')
@@ -582,14 +582,14 @@ class JslSecrets(WritableBaseModel):
             license_info = LicenseInfo(jsl_secrets=secrets, products=products, id=str(len(license_infos.infos)))
             license_infos.infos[file_name] = license_info
             license_infos.write(settings.creds_info_file)
-            out_dir = f'{settings.license_dir}/{file_name}'
+            out_dir = os.path.join(settings.license_dir, file_name)
             secrets.write(out_dir)
             print(f'📋 Stored new John Snow Labs License in {out_dir}')
         else:
             file_name = file_name.format(number='0')
             license_info = LicenseInfo(jsl_secrets=secrets, products=products, id='0')
             LicenseInfos(infos={file_name: license_info}).write(settings.creds_info_file)
-            out_dir = f'{settings.license_dir}/{file_name}'
+            out_dir = os.path.join(settings.license_dir, file_name)
             secrets.write(out_dir)
             print(f'📋 Stored John Snow Labs License in {out_dir}')
             # We might load again JSL-Secrets from local

--- a/johnsnowlabs/py_models/jsl_secrets.py
+++ b/johnsnowlabs/py_models/jsl_secrets.py
@@ -342,14 +342,14 @@ class JslSecrets(WritableBaseModel):
 
     @staticmethod
     def json_path_as_dict(path):
-        with open(path) as f:
+        with open(path, "r", encoding="utf8") as f:
             return json.load(f)
 
     @staticmethod
     def from_json_file_path(secrets_path):
         if not os.path.exists(secrets_path):
             raise FileNotFoundError(f'No file found for secrets_path={secrets_path}')
-        f = open(secrets_path)
+        f = open(secrets_path, "r", encoding="utf8")
         creds = JslSecrets.from_json_dict(json.load(f))
         f.close()
         return creds
@@ -389,7 +389,7 @@ class JslSecrets(WritableBaseModel):
         return secrets
 
     @staticmethod
-    def from_json_dict(secrets, secrets_metadata: Optional = None) -> 'JslSecrets':
+    def from_json_dict(secrets, secrets_metadata: Optional[dict] = None) -> 'JslSecrets':
         hc_secret = secrets['JSL_SECRET'] if 'JSL_SECRET' in secrets else None
         if not hc_secret:
             hc_secret = secrets['SECRET'] if 'SECRET' in secrets else None
@@ -475,16 +475,16 @@ class JslSecrets(WritableBaseModel):
         hc_secrets = new_secrets.HC_SECRET
         ocr_secret = new_secrets.OCR_SECRET
         invalid_licenses = []
-        for license in os.listdir(settings.license_dir):
-            if license == 'info.json':
+        for license_file in os.listdir(settings.license_dir):
+            if license_file == 'info.json':
                 continue
-            secrets = JslSecrets.parse_file(f'{settings.license_dir}/{license}')
+            secrets = JslSecrets.parse_file(f'{settings.license_dir}/{license_file}')
             if secrets.HC_SECRET and hc_secrets and \
                     JslSecrets.is_other_older_secret(hc_secrets, secrets.HC_SECRET):
-                invalid_licenses.append(f'{settings.license_dir}/{license}')
+                invalid_licenses.append(f'{settings.license_dir}/{license_file}')
             elif secrets.OCR_SECRET and ocr_secret \
                     and JslSecrets.is_other_older_secret(ocr_secret, secrets.OCR_SECRET):
-                invalid_licenses.append(f'{settings.license_dir}/{license}')
+                invalid_licenses.append(f'{settings.license_dir}/{license_file}')
 
         for license_path in invalid_licenses:
             print(f'Updating license file {license_path}')

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -1,4 +1,4 @@
-from os.path import expanduser
+from os.path import expanduser, join
 
 # libs, these versions are used for auto-installs and version  checks
 from johnsnowlabs.utils.env_utils import is_running_in_databricks, set_py4j_logger_to_error_on_databricks, \
@@ -37,18 +37,18 @@ else:
         # on Docker and other setups, ~ may resolve to `/`, so we need special handling here
         root_dir = f'{expanduser("~")}.johnsnowlabs'
     else:
-        root_dir = f'{expanduser("~")}/.johnsnowlabs'
+        root_dir = join(home, '.johnsnowlabs')
 
 ## Directories
-license_dir = f'{root_dir}/licenses'
-java_dir = f'{root_dir}/java_installs'
-py_dir = f'{root_dir}/py_installs'
+license_dir = join(root_dir, "licenses")
+java_dir = join(root_dir, 'java_installs')
+py_dir = join(root_dir, 'py_installs')
 
 # Info Files
-root_info_file = f'{root_dir}/info.json'
-java_info_file = f'{java_dir}/info.json'
-py_info_file = f'{py_dir}/info.json'
-creds_info_file = f'{license_dir}/info.json'
+root_info_file = join(root_dir, 'info.json')
+java_info_file = join(java_dir, 'info.json')
+py_info_file = join(py_dir, 'info.json')
+creds_info_file = join(license_dir, 'info.json')
 
 # databricks paths
 dbfs_home_dir = 'dbfs:/johnsnowlabs'

--- a/johnsnowlabs/utils/file_utils.py
+++ b/johnsnowlabs/utils/file_utils.py
@@ -3,23 +3,23 @@ from typing import Dict, Any
 
 
 def dump_dataclass_to_json(data_class_instance, out_file_path, overwrite_if_exist: bool = True):
-    with open(out_file_path, 'w') as json_file:
+    with open(out_file_path, 'w', encoding="utf8") as json_file:
         json.dump(data_class_instance.__dict__, json_file, indent=4)
 
 
 def json_path_as_dict(path) -> Dict[Any, Any]:
-    with open(path) as f:
+    with open(path, "r", encoding="utf8") as f:
         return json.load(f)
 
 
 def str_to_file(str_, path):
-    with open(path, "w") as text_file:
+    with open(path, "w", encoding="utf8") as text_file:
         text_file.write(str_)
     return path
 
 
 def file_to_str(path):
-    with open(path, 'r') as file:
+    with open(path, 'r', encoding="utf8") as file:
         return file.read()
 
 

--- a/johnsnowlabs/utils/modelhub_markdown.py
+++ b/johnsnowlabs/utils/modelhub_markdown.py
@@ -26,7 +26,7 @@ def modelhub_md_to_pyscript(path):
     end_s = '```'
     data = []
     started = False
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding="utf8") as f:
         for l in f:
             if start_s in l:
                 started = True

--- a/johnsnowlabs/utils/notebooks.py
+++ b/johnsnowlabs/utils/notebooks.py
@@ -23,7 +23,7 @@ def nbformat_to_ipynb(out_path, nb):
 
 
 def ipynb_to_nbformat(in_path):
-    with open(in_path) as f:
+    with open(in_path, "r", encoding="utf8") as f:
         return nbformat.read(f, as_version=4)
 
 
@@ -34,7 +34,7 @@ def get_all_nb_in_local_folder(p):
 
 def convert_notebook(notebookPath):
     out_path = f'{johnsnowlabs.utils.testing.test_settings.tmp_notebook_dir}/{path_tail(notebookPath)}.nb_converted.py'
-    with open(notebookPath) as fh:
+    with open(notebookPath, "r", encoding="utf8") as fh:
         nb = nbformat.reads(fh.read(), nbformat.NO_CONVERT)
     exporter = PythonExporter()
     source, meta = exporter.from_notebook_node(nb)

--- a/johnsnowlabs/utils/pip_utils.py
+++ b/johnsnowlabs/utils/pip_utils.py
@@ -67,34 +67,41 @@ def install_standard_pypi_lib(pypi_name: str,
     :param upgrade: use --upgrade flag or not 
     :return:
     """
-    if isinstance(version,LibVersion ):
+    if isinstance(version, LibVersion):
         version = version.as_str()
 
     if not pypi_name:
         raise Exception(f'Tried to install software which has no pypi file_name! Aborting.')
     print(f'Installing {pypi_name} to {python_path}')
-    c = f'{python_path} -m pip install {pypi_name}'
-    print(f'Running: {c}')
+    c = f'"{python_path}" -m pip install {pypi_name}'
     if version:
         c = c + f'=={version} '
     else:
         c = c + ' '
-
+    
+    subprocess_args = [c]
+    print(f'Running: {c}')
+    
     if upgrade:
         c = c + '--upgrade '
+        subprocess_args.append('--upgrade')
     if re_install:
         c = c + ' --force-reinstall'
+        subprocess_args.append('--force-reinstall')
 
     if download_folder:
         if version:
             c = f'{python_path} -m pip download {pypi_name}=={version} -d {download_folder}'
         else:
             c = f'{python_path} -m pip download {pypi_name} -d {download_folder}'
+        subprocess_args = [c]
 
     if not include_dependencies:
         c = c + ' --no-deps'
+        subprocess_args.append('--no-deps')
 
-    os.system(c)
+    #os.system(c)
+    out = subprocess.run(subprocess_args, shell=True, check=True, capture_output=True)
     if module_name and not download_folder:
         try:
             # See if install worked


### PR DESCRIPTION
I added the `encoding="utf8"` for all `open` calls I found to avoid encoding errors on different locales. 

I also added quotes surrounding `python_path` in the command:

```python
c = f'"{python_path}" -m pip install {pypi_name}'
```

so that when a user has white spaces in their Python path, the command continues to work. I was getting the error because my user is `David Cecchini`, and my Python path was `C:\Users\David Cecchini/.johnsnowlabs/py_installs/spark_nlp_jsl-4.2.4-py3-none-any.whl`, getting the error:

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/11304253/210413689-b11773c2-dac4-4c1b-9257-23bf55624759.png">
  