### PR TITLE
Pip install cmd fix

### DIFF
--- a/johnsnowlabs/py_models/jsl_secrets.py
+++ b/johnsnowlabs/py_models/jsl_secrets.py
@@ -606,22 +606,22 @@ class JslSecrets(WritableBaseModel):
         hc_secrets = new_secrets.HC_SECRET
         ocr_secret = new_secrets.OCR_SECRET
         invalid_licenses = []
-        for license in os.listdir(settings.license_dir):
-            if license == "info.json":
+        for license_file in os.listdir(settings.license_dir):
+            if license_file == "info.json":
                 continue
-            secrets = JslSecrets.parse_file(os.path.join(settings.license_dir, license))
+            secrets = JslSecrets.parse_file(os.path.join(settings.license_dir, license_file))
             if (
                 secrets.HC_SECRET
                 and hc_secrets
                 and JslSecrets.is_other_older_secret(hc_secrets, secrets.HC_SECRET)
             ):
-                invalid_licenses.append(os.path.join(settings.license_dir, license))
+                invalid_licenses.append(os.path.join(settings.license_dir, license_file))
             elif (
                 secrets.OCR_SECRET
                 and ocr_secret
                 and JslSecrets.is_other_older_secret(ocr_secret, secrets.OCR_SECRET)
             ):
-                invalid_licenses.append(os.path.join(settings.license_dir, license))
+                invalid_licenses.append(os.path.join(settings.license_dir, license_file))
 
         for license_path in invalid_licenses:
             print(f"Updating license file {license_path}")

--- a/johnsnowlabs/utils/my_jsl_api.py
+++ b/johnsnowlabs/utils/my_jsl_api.py
@@ -214,20 +214,20 @@ def ensure_correct_choice(licenses_count):
 
 def get_user_license_choice(licenses):
     print("Please select the license to use.")
-    for idx, license in enumerate(licenses):
-        products = ",".join(s["file_name"] for s in license["products"])
-        if license["platform"] is None:
+    for idx, license_dict in enumerate(licenses):
+        products = ",".join(s["file_name"] for s in license_dict["products"])
+        if license_dict["platform"] is None:
             scope = "Airgap"
         else:
-            scope = license["platform"]["file_name"]
-            type = license["platform"]["type"]
+            scope = license_dict["platform"]["file_name"]
+            platform_type = license_dict["platform"]["type"]
             if scope == "Floating":
-                if type:
-                    scope = scope + "," + type.capitalize()
+                if platform_type:
+                    scope = scope + "," + platform_type.capitalize()
 
         print(
             "{}. Libraries: {}\n   License Type: {}\n   Expiration Date: {}\n   Scope: {}".format(
-                idx + 1, products, license["type"], license["endDate"], scope
+                idx + 1, products, license_dict["type"], license_dict["endDate"], scope
             )
         )
 

--- a/johnsnowlabs/utils/pip_utils.py
+++ b/johnsnowlabs/utils/pip_utils.py
@@ -77,7 +77,7 @@ def install_standard_pypi_lib(
             f"Tried to install software which has no pypi file_name! Aborting."
         )
     print(f"Installing {pypi_name} to {python_path}")
-    c = f"{python_path} -m pip install {pypi_name}"
+    c = f'"{python_path}" -m pip install {pypi_name}'
     if version:
         c = c + f"=={version} "
     else:

--- a/setup.py
+++ b/setup.py
@@ -1,50 +1,51 @@
-from setuptools import setup, find_packages
-from codecs import open
+from codecs import open as copen
 from os import path
+from setuptools import setup, find_packages
 import johnsnowlabs.settings
+
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with copen(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 REQUIRED_PKGS = [
-    f'pyspark=={johnsnowlabs.settings.raw_version_pyspark}',
-    f'spark-nlp=={johnsnowlabs.settings.raw_version_nlp}',
-    f'nlu=={johnsnowlabs.settings.raw_version_nlu}',
-    f'spark-nlp-display=={johnsnowlabs.settings.raw_version_nlp_display}',
-    'numpy',
-    'dataclasses',
-    'requests',
-    'databricks-api',
-    'pydantic',
-    'colorama'
+    f"pyspark=={johnsnowlabs.settings.raw_version_pyspark}",
+    f"spark-nlp=={johnsnowlabs.settings.raw_version_nlp}",
+    f"nlu=={johnsnowlabs.settings.raw_version_nlu}",
+    f"spark-nlp-display=={johnsnowlabs.settings.raw_version_nlp_display}",
+    "numpy",
+    "dataclasses",
+    "requests",
+    "databricks-api",
+    "pydantic",
+    "colorama",
 ]
 
 setup(
     version=johnsnowlabs.settings.raw_version_jsl_lib,
     # name='johnsnowlabs_for_databricks',
-    name='johnsnowlabs',
-    description='The John Snow Labs Library gives you access to all of John Snow Labs Enterprise And Open Source products in an easy and simple manner. Access 10000+ state-of-the-art NLP and OCR models for '
-                'Finance, Legal and Medical domains. Easily scalable to Spark Cluster ',
+    name="johnsnowlabs",
+    description="The John Snow Labs Library gives you access to all of John Snow Labs Enterprise And Open Source products in an easy and simple manner. Access 10000+ state-of-the-art NLP and OCR models for "
+    "Finance, Legal and Medical domains. Easily scalable to Spark Cluster ",
     long_description=long_description,
     install_requires=REQUIRED_PKGS,
-    long_description_content_type='text/markdown',
-    url='https://www.johnsnowlabs.com/',
-    author='John Snow Labs',
-    author_email='christian@johnsnowlabs.com',
+    long_description_content_type="text/markdown",
+    url="https://www.johnsnowlabs.com/",
+    author="John Snow Labs",
+    author_email="christian@johnsnowlabs.com",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-        'License :: OSI Approved :: Apache Software License',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Build Tools",
+        "License :: OSI Approved :: Apache Software License",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
-    keywords='Spark NLP OCR Finance Legal Medical John Snow Labs  ',
-    packages=find_packages(exclude=['test*', 'tmp*']),  # exclude=['test']
-    include_package_data=True
+    keywords="Spark NLP OCR Finance Legal Medical John Snow Labs  ",
+    packages=find_packages(exclude=["test*", "tmp*"]),  # exclude=['test']
+    include_package_data=True,
 )

--- a/tests/auto_install.py
+++ b/tests/auto_install.py
@@ -15,21 +15,21 @@ class AutoInstallTestCase(unittest.TestCase):
 
     def test_quick_bad(self):
         jsl.settings.enforce_versions = False
-        jsl.install(enterprise_nlp_secret=sct.enterprise_nlp_sct)
+        nlp.install(enterprise_nlp_secret=sct.enterprise_nlp_sct)
 
     def test_install_to_databricks_creating_new_cluster(self):
-        cluster_id = jsl.install(json_license_path=sct.db_lic, databricks_host=sct.ckl_host,
+        cluster_id = nlp.install(json_license_path=sct.db_lic, databricks_host=sct.ckl_host,
                                  databricks_token=sct.ckl_token)
 
     def test_install_to_databricks_existing_cluster(self):
         # TODO WIP
         cluster_id = '1006-022913-lb94q2m0'
-        jsl.install(json_license_path=sct.db_lic, databricks_host=sct.ckl_host, databricks_cluster_id=cluster_id)
+        nlp.install(json_license_path=sct.db_lic, databricks_host=sct.ckl_host, databricks_cluster_id=cluster_id)
         db = get_db_client_for_token(sct.ckl_host, sct.ckl_token)
         # install_py_lib_via_pip(db, cluster_id, 'nlu')
 
     def test_install_to_current_env_browser_pop_up(self):
-        jsl.install(force_browser=True, local_license_number=0)
+        nlp.install(force_browser=True, local_license_number=0)
         import sparknlp
         import sparknlp_jsl
         import sparkocr
@@ -38,7 +38,7 @@ class AutoInstallTestCase(unittest.TestCase):
 
     def test_install_to_current_env(self):
         settings.enforce_versions = False
-        jsl.install(json_license_path=sct.old_lic, refresh_install=True)
+        nlp.install(json_license_path=sct.old_lic, refresh_install=True)
         # import sparknlp
         import sparknlp_jsl
         import sparkocr
@@ -51,7 +51,7 @@ class AutoInstallTestCase(unittest.TestCase):
         f = '/home/ckl/old_home/ckl/Documents/freelance/johnsnowlabs_lib/tmp/licenses/ocr_40.json'
         VenvWrapper.create_venv(self.venv_creation_dir)
         py_path = VenvWrapper.glob_py_exec_from_venv(self.venv_creation_dir)
-        jsl.install(json_license_path=f, python_exec_path=py_path)
+        nlp.install(json_license_path=f, python_exec_path=py_path)
         self.assertTrue(VenvWrapper.is_lib_in_venv(self.venv_creation_dir, 'sparknlp'))
         self.assertTrue(VenvWrapper.is_lib_in_venv(self.venv_creation_dir, 'sparkocr'))
         self.assertTrue(VenvWrapper.is_lib_in_venv(self.venv_creation_dir, 'sparknlp_display'))
@@ -64,7 +64,7 @@ class AutoInstallTestCase(unittest.TestCase):
         # let jsl-lib create a fresh venv for us
         os.system(f'rm -r {self.venv_creation_dir} ')
         f = '/home/ckl/old_home/ckl/Documents/freelance/johnsnowlabs_lib/tmp/licenses/ocr_40.json'
-        jsl.install(json_license_path=f, venv_creation_path=self.venv_creation_dir)
+        nlp.install(json_license_path=f, venv_creation_path=self.venv_creation_dir)
         self.assertTrue(VenvWrapper.is_lib_in_venv(self.venv_creation_dir, 'sparknlp'))
         self.assertTrue(VenvWrapper.is_lib_in_venv(self.venv_creation_dir, 'sparkocr'))
         self.assertTrue(VenvWrapper.is_lib_in_venv(self.venv_creation_dir, 'sparknlp_display'))
@@ -83,22 +83,22 @@ class AutoInstallTestCase(unittest.TestCase):
         log_outdated_lib(Software.spark_ocr, '79')
 
     def test_offline_install_print(self):
-        jsl.install(offline=True)
+        nlp.install(offline=True)
 
     def test_offline_install_zip(self):
         os.system(f'rm -r {self.zip_dir} ')
-        jsl.install(offline=True, offline_zip_dir=self.zip_dir, install_optional=True, include_dependencies=True)
+        nlp.install(offline=True, offline_zip_dir=self.zip_dir, install_optional=True, include_dependencies=True)
 
     def test_browser_install(self):
-        jsl.install(force_browser=True, local_license_number=2)
-        # jsl.install(local_license_number=2, force_browser=True)
+        nlp.install(force_browser=True, local_license_number=2)
+        # nlp.install(local_license_number=2, force_browser=True)
 
     def test_upgrade_licensed_lib_via_secret_only(self):
         new_secret = ''
-        jsl.install(ocr_secret=new_secret)
+        nlp.install(ocr_secret=new_secret)
 
     def test_json_license_install(self):
-        jsl.install(json_license_path=sct.latest_lic)
+        nlp.install(json_license_path=sct.latest_lic)
         import sparknlp
         import sparknlp_jsl
         import sparknlp
@@ -106,11 +106,11 @@ class AutoInstallTestCase(unittest.TestCase):
         # import sparkocr
         import nlu
         import sparknlp_display
-        # jsl.install(json_license_path=old_lic)
+        # nlp.install(json_license_path=old_lic)
 
     def test_json_license_install_outdated(self):
         jsl.settings.enforce_versions = False
-        jsl.install(json_license_path=sct.old_lic)
+        nlp.install(json_license_path=sct.old_lic)
         import sparknlp
         import sparknlp_jsl
         import sparknlp
@@ -118,7 +118,7 @@ class AutoInstallTestCase(unittest.TestCase):
         # import sparkocr
         import nlu
         import sparknlp_display
-        # jsl.install(json_license_path=old_lic)
+        # nlp.install(json_license_path=old_lic)
 
     def test_create_and_install_cluster(self):
         install_suite = get_install_suite_from_jsl_home()
@@ -155,11 +155,11 @@ class AutoInstallTestCase(unittest.TestCase):
 
     def test_refresh_credentials(self):
         # Use this to upgrade all secrets on every license file, if greater
-        jsl.install(json_license_path=sct.latest_lic, only_refresh_credentials=True)
+        nlp.install(json_license_path=sct.latest_lic, only_refresh_credentials=True)
 
     def test_refresh_install(self):
         # Use this to upgrade all secrets on every license file, if greater
-        jsl.install(json_license_path=sct.latest_lic, refresh_install=True)
+        nlp.install(json_license_path=sct.latest_lic, refresh_install=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I changed some variable names to avoid conflict with built-in names (license from the `site` library and `type`).

I also re-added the quoted on the python path when installing the libraries with the `pip install` command (allowing white spaces in the path). The change was lost somewhere in the history of commits.