### PR TITLE
Release/430

### DIFF
--- a/johnsnowlabs/auto_install/lib_resolvers/nlp_installer.py
+++ b/johnsnowlabs/auto_install/lib_resolvers/nlp_installer.py
@@ -55,7 +55,7 @@ class NlpLibResolver(Py4JJslLibDependencyResolverABC, metaclass=ABCMeta):
         SparkVersion.spark3xx: {
             # TODO HARDCODE HASH!!! OR grap from enum or somwhere comfy. Maybe configs/settings file?
             PyInstallTypes.wheel: UrlDependency(
-                url="https://files.pythonhosted.org/packages/53/ed/b90d8ce6dcacb824d72682100bb717e07a6c2c04748a80d14fc6f2ec3360/spark_nlp-{lib_version}-py2.py3-none-any.whl",
+                url="https://files.pythonhosted.org/packages/8d/17/dd5228ac3a802284af8be106c9b16e28c24c8b08098ec6f6e464419060fd/spark_nlp-{lib_version}-py2.py3-none-any.whl",
                 dependency_type=PyInstallTypes.wheel,
                 spark_version=SparkVersion.spark3xx,
                 product_name=product_name,
@@ -63,7 +63,7 @@ class NlpLibResolver(Py4JJslLibDependencyResolverABC, metaclass=ABCMeta):
                 dependency_version=lib_version,
             ),
             PyInstallTypes.tar: UrlDependency(
-                url="https://files.pythonhosted.org/packages/5a/af/9c73a6a6a74f2848209001194bef19b74cfe04fdd070aec529d290ce239d/spark-nlp-{lib_version}.tar.gz",
+                url="https://files.pythonhosted.org/packages/bb/72/09e32b9a41e698cb7a86a8999641bf6ea8d0604235893819d9aecb08c731/spark-nlp-{lib_version}.tar.gz",
                 dependency_type=PyInstallTypes.tar,
                 spark_version=SparkVersion.spark3xx,
                 product_name=product_name,

--- a/johnsnowlabs/finance.py
+++ b/johnsnowlabs/finance.py
@@ -10,6 +10,8 @@ try:
         from sparknlp_jsl.base import FeaturesAssembler
 
         from sparknlp_jsl.finance import (
+
+            GenericClassifierModel,
             FinanceNerQuestionGenerator as NerQuestionGenerator,
             FinanceDocumentHashCoder as DocumentHashCoder,
             FinanceBertForTokenClassification as BertForTokenClassification,
@@ -38,6 +40,10 @@ try:
 
         # These are licensed annos shared across all libs
         from sparknlp_jsl.annotator import (
+            GenericSVMClassifierApproach,
+            GenericSVMClassifierModel,
+            GenericLogRegClassifierApproach,
+            GenericClassifierModel,
             SentenceDetector as TextSplitter,
             MedicalDistilBertForSequenceClassification as DistilBertForSequenceClassification,
             AssertionChunkConverter,
@@ -83,7 +89,7 @@ try:
         )
 
         from sparknlp_jsl.modelTracer import ModelTracer
-        from sparknlp_jsl import training_log_parser
+        from sparknlp_jsl import (training_log_parser, Deid)
         from sparknlp_jsl.compatibility import Compatibility
         from sparknlp_jsl.pretrained import InternalResourceDownloader
         from sparknlp_jsl.eval import (

--- a/johnsnowlabs/legal.py
+++ b/johnsnowlabs/legal.py
@@ -34,6 +34,10 @@ try:
 
         # These are licensed annos shared across all libs
         from sparknlp_jsl.annotator import (
+            GenericSVMClassifierApproach,
+            GenericSVMClassifierModel,
+            GenericLogRegClassifierApproach,
+            GenericClassifierModel,
             SentenceDetector as TextSplitter,
             MedicalDistilBertForSequenceClassification as DistilBertForSequenceClassification,
             AssertionChunkConverter,
@@ -82,7 +86,8 @@ try:
 
         from sparknlp_jsl.structured_deidentification import StructuredDeidentification
 
-        from sparknlp_jsl import training_log_parser
+        from sparknlp_jsl import (training_log_parser, Deid)
+
         from sparknlp_jsl.compatibility import Compatibility
         from sparknlp_jsl.pretrained import InternalResourceDownloader
         from sparknlp_jsl.eval import (

--- a/johnsnowlabs/medical.py
+++ b/johnsnowlabs/medical.py
@@ -10,6 +10,10 @@ try:
     if try_import_lib("sparknlp_jsl") and try_import_lib("sparknlp"):
         # Pretrained
         from sparknlp_jsl.annotator import (
+            GenericSVMClassifierApproach,
+            GenericSVMClassifierModel,
+            GenericLogRegClassifierApproach,
+            GenericClassifierModel,
             AssertionLogRegModel,
             AssertionDLModel,
             DeIdentificationModel,
@@ -66,22 +70,19 @@ try:
         )
         from sparknlp_jsl.structured_deidentification import StructuredDeidentification
         from sparknlp_jsl.modelTracer import ModelTracer
-        from sparknlp_jsl import training_log_parser
+        from sparknlp_jsl import (training_log_parser, Deid)
 
         from sparknlp_jsl.base import FeaturesAssembler
 
         from sparknlp_jsl.annotator.resolution.resolver_merger import ResolverMerger
 
-        from sparknlp_jsl.annotator import MedicalNerModel as NerModel
-        from sparknlp_jsl.annotator import MedicalNerApproach as NerApproach
-        from sparknlp_jsl.annotator import (
-            MedicalBertForTokenClassifier as BertForTokenClassification,
-        )
         from sparknlp_jsl.annotator import (
             MedicalDistilBertForSequenceClassification as DistilBertForSequenceClassification,
-        )
-        from sparknlp_jsl.annotator import (
             MedicalBertForSequenceClassification as BertForSequenceClassification,
+            MedicalBertForTokenClassifier as BertForTokenClassification,
+            MedicalNerModel as NerModel,
+            MedicalNerApproach as NerApproach,
+
         )
         from sparknlp_jsl.compatibility import Compatibility
         from sparknlp_jsl.pretrained import InternalResourceDownloader

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -8,14 +8,14 @@ from johnsnowlabs.utils.env_utils import (
 )
 
 # These versions are used for auto-installs and version  checks
-raw_version_jsl_lib = "4.2.8"
-raw_version_nlp = "4.2.8"
+raw_version_jsl_lib = "4.3.0"
+raw_version_nlp = "4.3.0"
 raw_version_nlu = "4.0.1rc4"
 raw_version_pyspark = "3.1.2"
 raw_version_nlp_display = "4.1"
 
-raw_version_medical = "4.2.8"
-raw_version_secret_medical = "4.2.8"
+raw_version_medical = "4.3.0"
+raw_version_secret_medical = "4.3.0"
 
 raw_version_secret_ocr = "4.3.0"
 raw_version_ocr = "4.3.0"


### PR DESCRIPTION
- bump enterprise NLP and open source NLP to 4.3.0
- Generic Log Reg and Generic SVM available for `finance`, `legal` and `medical` modules 
- Hubert, Swin Transformer , Zero-SHOT NER , CamemBert for QA for `nlp` module