### PR TITLE
FEATURE NMH-168: Fix license models url

### DIFF
--- a/docs/_posts/2020-05-23-ner_clinical_large_en.md
+++ b/docs/_posts/2020-05-23-ner_clinical_large_en.md
@@ -109,7 +109,7 @@ The output is a dataframe with a sentence per row and a ``"ner"`` column contain
 |Type:|ner|
 |Compatibility:|Spark NLP 2.5.0+|
 |Edition:|Official|
-|License:|Licenced|
+|License:|Licensed|
 |Input Labels:|[sentence, token, embeddings]|
 |Output Labels:|[ner]|
 |Language:|[en]|


### PR DESCRIPTION
Jira Ticket [NMH-168](https://johnsnowlabs.atlassian.net/browse/NMH-168)

If licensed models mistakenly have origin=https://sparknlp.org, this might cause data errors in the returning aggregations of search service