### PR TITLE
Deprecate visualner v2 models

### DIFF
--- a/docs/_posts/aymanechilah/2023-01-10-visualner_10kfilings_en_3_2.md
+++ b/docs/_posts/aymanechilah/2023-01-10-visualner_10kfilings_en_3_2.md
@@ -10,7 +10,7 @@ language: en
 nav_key: models
 edition: Visual NLP 4.0.0
 spark_version: 3.2
-supported: true
+deprecated: true
 annotator: VisualDocumentNERv21
 article_header:
   type: cover

--- a/docs/_posts/aymanechilah/2023-01-10-visualner_keyvalue_10kfilings_en_3_2.md
+++ b/docs/_posts/aymanechilah/2023-01-10-visualner_keyvalue_10kfilings_en_3_2.md
@@ -10,7 +10,7 @@ language: en
 nav_key: models
 edition: Visual NLP 4.0.0
 spark_version: 3.2
-supported: true
+deprecated: true
 annotator: VisualDocumentNERv21
 article_header:
   type: cover

--- a/docs/_posts/josejuanmartinez/2022-09-21-visualner_10kfilings_en.md
+++ b/docs/_posts/josejuanmartinez/2022-09-21-visualner_10kfilings_en.md
@@ -10,7 +10,7 @@ language: en
 nav_key: models
 edition: Visual NLP 4.0.0
 spark_version: 3.2
-supported: true
+deprecated: true
 annotator: VisualDocumentNERv21
 article_header:
   type: cover

--- a/docs/_posts/josejuanmartinez/2022-09-21-visualner_keyvalue_10kfilings_en.md
+++ b/docs/_posts/josejuanmartinez/2022-09-21-visualner_keyvalue_10kfilings_en.md
@@ -10,7 +10,7 @@ language: en
 nav_key: models
 edition: Visual NLP 4.0.0
 spark_version: 3.2
-supported: true
+deprecated: true
 annotator: VisualDocumentNERv21
 article_header:
   type: cover

--- a/docs/_posts/josejuanmartinez/2022-09-21-visualner_receipts_xx.md
+++ b/docs/_posts/josejuanmartinez/2022-09-21-visualner_receipts_xx.md
@@ -9,7 +9,7 @@ task: OCR Object Detection
 language: xx
 edition: Visual NLP 4.0.0
 spark_version: 3.2
-supported: true
+deprecated: true
 annotator: VisualDocumentNERv21
 article_header:
   type: cover


### PR DESCRIPTION
Then annotator is deprecated, but users can still find the models on MH. We need to deprecate them and train the models using the new annotators.