### PR TITLE
Fix update existing databricks cluster

### DIFF
--- a/johnsnowlabs/auto_install/install_flow.py
+++ b/johnsnowlabs/auto_install/install_flow.py
@@ -171,6 +171,9 @@ def install(
                 db=get_db_client_for_token(databricks_host, databricks_token),
                 install_suite=suite,
                 cluster_id=databricks_cluster_id,
+                medical_nlp=nlp,
+                spark_nlp=spark_nlp,
+                visual=visual,
             )
 
         else:

--- a/johnsnowlabs/py_models/jsl_secrets.py
+++ b/johnsnowlabs/py_models/jsl_secrets.py
@@ -224,19 +224,14 @@ class JslSecrets(WritableBaseModel):
         try:
             # we wrap this flow with try/except, so that incase we get invalid license data
             # we can still try loading from JSL-Home afterwards
-            if all(
+            if any(
                 [
-                    any(
-                        [
-                            hc_license,
-                            hc_secret,
-                            ocr_secret,
-                            ocr_license,
-                            fin_license,
-                            leg_license,
-                        ]
-                    ),
-                    all([aws_access_key, aws_key_id]),
+                    hc_license,
+                    hc_secret,
+                    ocr_secret,
+                    ocr_license,
+                    fin_license,
+                    leg_license,
                 ]
             ):
                 # Some found_secrets are supplied


### PR DESCRIPTION
- Fix update databricks cluster
- nlp.install(med_license=<license>) should work without aws keys for floating licenses