### PR TITLE
Only import boto3 in function calls

### DIFF
--- a/johnsnowlabs/auto_install/emr/install_utils.py
+++ b/johnsnowlabs/auto_install/emr/install_utils.py
@@ -2,9 +2,6 @@ import time
 from os import path
 from typing import Optional
 
-import boto3
-import botocore
-
 from johnsnowlabs import settings
 from johnsnowlabs.auto_install.emr.enums import EMRClusterStates
 from johnsnowlabs.auto_install.emr.work_utils import create_emr_bucket
@@ -18,7 +15,7 @@ here = path.abspath(path.dirname(__file__))
 
 
 def create_emr_cluster(
-    boto_session: boto3.Session,
+    boto_session: "boto3.Session",
     secrets: JslSecrets,
     bootstrap_bucket: Optional[str] = None,
     s3_logs_path: Optional[str] = None,
@@ -54,6 +51,8 @@ def create_emr_cluster(
     # Refer: https://docs.aws.amazon.com/emr/latest/APIReference/API_RunJobFlow.html
     # Refer Also: https://docs.aws.amazon.com/code-library/latest/ug/python_3_emr_code_examples.html
     """
+
+    import botocore
 
     try:
         if not boto_session:
@@ -205,7 +204,9 @@ def block_till_emr_cluster_ready(emr_client, cluster_id: str):
     print(f"👌 Cluster-Id {cluster_id} is ready!")
 
 
-def create_initialization_step_script(boto_session: boto3.Session, bucket: str) -> str:
+def create_initialization_step_script(
+    boto_session: "boto3.Session", bucket: str
+) -> str:
     """Creates a EMR initialization step script and uploads it to s3 bucket. Returns the s3 path of the script
     :param boto_session: Boto3 session
     :param s3_client: S3 boto3 client
@@ -223,6 +224,7 @@ sudo python3 -m pip install "numpy>1.17.3"
 sudo python3 -m pip install scipy scikit-learn "tensorflow==2.11.0" tensorflow-addons
 exit 0
 """
+
     return upload_content(
         boto_session=boto_session,
         bucket=bucket,
@@ -232,7 +234,7 @@ exit 0
 
 
 def create_bootstrap_script(
-    boto_session: boto3.Session,
+    boto_session: "boto3.Session",
     bucket: str,
     secrets: JslSecrets,
     spark_nlp: bool = True,

--- a/johnsnowlabs/auto_install/glue/install_utils.py
+++ b/johnsnowlabs/auto_install/glue/install_utils.py
@@ -1,6 +1,5 @@
 from typing import List, Optional, Tuple
 
-import boto3
 import botocore
 
 from johnsnowlabs.py_models.install_info import InstallSuite, LocalPy4JLib
@@ -8,11 +7,13 @@ from johnsnowlabs.utils.boto_utils import BotoException
 from johnsnowlabs.utils.s3_utils import create_bucket, upload_file_to_s3
 
 
-def create_glue_bucket(boto_session: boto3.Session, bucket=None):
+def create_glue_bucket(boto_session: "boto3.Session", bucket=None):
     """Create a bucket for EMR cluster logs
     :param boto_session: Boto3 session
     :param bucket: Bucket name
     """
+    import boto3
+
     try:
         sts_client = boto_session.client("sts")
         account_id = sts_client.get_caller_identity()["Account"]
@@ -31,7 +32,7 @@ def create_glue_bucket(boto_session: boto3.Session, bucket=None):
 
 
 def upload_pylibs_jars_to_glue_bucket(
-    boto_session: boto3.Session, install_suite: InstallSuite, bucket: Optional[str]
+    boto_session: "boto3.Session", install_suite: InstallSuite, bucket: Optional[str]
 ) -> Tuple[List[str], List[str]]:
     """Uploads jars and python packages to glue bucket
     :param boto_session: Boto3 session
@@ -39,6 +40,8 @@ def upload_pylibs_jars_to_glue_bucket(
     :param bucket: Bucket name
     :return: List of uploaded jars and python packages
     """
+    import boto3
+
     if not boto_session:
         raise ValueError("Boto3 session is required")
 

--- a/johnsnowlabs/auto_install/glue/utils.py
+++ b/johnsnowlabs/auto_install/glue/utils.py
@@ -1,6 +1,5 @@
 from typing import List, Optional
 
-import boto3
 
 from johnsnowlabs import settings
 from johnsnowlabs.auto_install.softwares import Software
@@ -9,7 +8,7 @@ from johnsnowlabs.utils.boto_utils import get_aws_used_creds
 
 
 def get_printable_glue_notebook_commands(
-    boto_session: boto3.Session,
+    boto_session: "boto3.Session",
     glue_assets_bucket: str,
     packages_s3_location: List[str],
     jars_s3_location: List[str],

--- a/johnsnowlabs/auto_install/install_flow.py
+++ b/johnsnowlabs/auto_install/install_flow.py
@@ -3,7 +3,6 @@ import shutil
 import sys
 from typing import Optional, List
 
-import boto3
 
 from johnsnowlabs import settings
 from johnsnowlabs.auto_install.databricks.dbfs import dbfs_rm
@@ -400,7 +399,7 @@ def install_to_databricks(
 
 
 def install_to_emr(
-    boto_session: Optional[boto3.Session] = None,
+    boto_session: Optional["boto3.Session"] = None,
     # EMR specific configs
     bootstrap_bucket: Optional[str] = None,
     s3_logs_path: Optional[str] = None,
@@ -449,6 +448,8 @@ def install_to_emr(
     :param auto_terminate_hours : Idle hour to wait before terminating the cluster
     :return: EMR cluster id
     """
+    import boto3
+
     secrets: JslSecrets = JslSecrets.build_or_try_find_secrets(
         browser_login=browser_login,
         force_browser=force_browser,
@@ -486,7 +487,7 @@ def install_to_emr(
 
 
 def install_to_glue(
-    boto_session: Optional[boto3.Session] = None,
+    boto_session: Optional["boto3.Session"] = None,
     glue_assets_bucket: Optional[str] = None,
     # Browser Auth
     browser_login: bool = True,
@@ -522,6 +523,8 @@ def install_to_glue(
     :param hardware_platform: Hardware platform
 
     """
+    import boto3
+
     if not boto_session:
         boto_session = boto3.Session()
 

--- a/johnsnowlabs/utils/boto_utils.py
+++ b/johnsnowlabs/utils/boto_utils.py
@@ -1,8 +1,3 @@
-from os import environ
-
-import boto3
-
-
 class BotoException(Exception):
     def __init__(self, code, message):
         self.code = code

--- a/johnsnowlabs/utils/s3_utils.py
+++ b/johnsnowlabs/utils/s3_utils.py
@@ -1,8 +1,5 @@
 from typing import Tuple
 
-import boto3
-import botocore
-
 from johnsnowlabs.utils.boto_utils import BotoException
 
 
@@ -11,11 +8,13 @@ def parse_s3_url(s3_url: str) -> Tuple[str, str]:
     return s3_url.split("/")[2], "/".join(s3_url.split("/")[3:]).rstrip("/")
 
 
-def create_bucket(boto_session: boto3.Session, bucket: str):
+def create_bucket(boto_session: "boto3.Session", bucket: str):
     """Create a bucket for EMR cluster logs
     :param boto_session: Botocore session
     :param bucket: Bucket name
     """
+    import botocore
+
     try:
         s3_client = boto_session.client("s3")
         region = boto_session.region_name
@@ -37,11 +36,13 @@ def create_bucket(boto_session: boto3.Session, bucket: str):
         )
 
 
-def check_if_file_exists_in_s3(boto_session: boto3.Session, s3_url: str):
+def check_if_file_exists_in_s3(boto_session: "boto3.Session", s3_url: str):
     """Check if file exists in s3 using s3 client
     :param boto_session : Botocore session
     :param s3_url: S3 url to check
     """
+    import botocore
+
     try:
         s3_client = boto_session.client("s3")
         bucket, key = parse_s3_url(s3_url)
@@ -55,7 +56,7 @@ def check_if_file_exists_in_s3(boto_session: boto3.Session, s3_url: str):
 
 
 def upload_file_to_s3(
-    boto_session: boto3.Session, file_path: str, bucket: str, file_name: str
+    boto_session: "boto3.Session", file_path: str, bucket: str, file_name: str
 ) -> str:
     """Upload a file to s3 bucket
     :botocore_session: Botocore session
@@ -64,6 +65,8 @@ def upload_file_to_s3(
     :param file_name: File name to create
     :return s3_url: S3 url of uploaded file
     """
+    import botocore
+
     try:
         s3_client = boto_session.client("s3")
         s3_client.upload_file(file_path, bucket, file_name)
@@ -75,8 +78,10 @@ def upload_file_to_s3(
 
 
 def upload_content(
-    boto_session: boto3.Session, content: str, bucket: str, file_name: str
+    boto_session: "boto3.Session", content: str, bucket: str, file_name: str
 ) -> str:
+    import botocore
+
     """Upload content to s3 bucket
     :param boto_session: Botocore session
     :param content: Content to upload

--- a/johnsnowlabs/utils/sparksession_utils.py
+++ b/johnsnowlabs/utils/sparksession_utils.py
@@ -116,6 +116,7 @@ def start(
     )
 
     # Collect all local Jar Paths we have access to for the SparkSession
+    Software.spark_nlp.check_installed(None)  # TODO REMOVE THIS LINE
     jars = []
     if (
         spark_nlp


### PR DESCRIPTION
in some environments importing boto3 can throw an exceptions, especially databricks.
Many times users will not use boto3 functions of jsl-lib, so we can just import within the functions and use "boto3.abc" for referencing classes in function signatures