### PR TITLE
Addition new healthcare annotations to johnsnowlabs

### DIFF
--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -15,11 +15,28 @@ sidebar:
 
 See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for detailed information on Release History and Features
 
+# 5.3.4
+Release date: 4-12-2024
+
+The John Snow Labs 5.3.4 Library released with the following pre-installed and recommended dependencies
+
+
+| Library                                                                                 | Version |
+|-----------------------------------------------------------------------------------------|---------|
+| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `5.3.0` |
+| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `5.3.0` |
+| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X` |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X` |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.3.0` |
+| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `4.4`   |
+| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `5.3.1` |
+| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0` |
+
 
 # 5.3.3
-Release date: 4-5-2023
+Release date: 4-5-2024
 
-The John Snow Labs 5.3.2 Library released with the following pre-installed and recommended dependencies
+The John Snow Labs 5.3.3 Library released with the following pre-installed and recommended dependencies
 
 
 | Library                                                                                 | Version |
@@ -36,7 +53,7 @@ The John Snow Labs 5.3.2 Library released with the following pre-installed and r
 
 
 # 5.3.2
-Release date: 3-13-2023
+Release date: 3-13-2024
 
 The John Snow Labs 5.3.2 Library released with the following pre-installed and recommended dependencies
 
@@ -56,7 +73,7 @@ The John Snow Labs 5.3.2 Library released with the following pre-installed and r
 
 
 # 5.3.1
-Release date: 3-12-2023
+Release date: 3-12-2024
 
 The John Snow Labs 5.3.1 Library released with the following pre-installed and recommended dependencies
 
@@ -75,7 +92,7 @@ The John Snow Labs 5.3.1 Library released with the following pre-installed and r
 
 
 # 5.3.0
-Release date: 3-8-2023
+Release date: 3-8-2024
 
 The John Snow Labs 5.3.0 Library released with the following pre-installed and recommended dependencies
 
@@ -95,7 +112,7 @@ The John Snow Labs 5.3.0 Library released with the following pre-installed and r
 
 
 ## 5.2.8
-Release date: 2-15-2023
+Release date: 2-15-2024
 
 The John Snow Labs 5.2.8 Library released with the following pre-installed and recommended dependencies
 
@@ -114,7 +131,7 @@ The John Snow Labs 5.2.8 Library released with the following pre-installed and r
 
 
 # 5.2.7
-Release date: 2-15-2023
+Release date: 2-15-2024
 
 The John Snow Labs 5.2.7 Library released with the following pre-installed and recommended dependencies
 
@@ -133,7 +150,7 @@ The John Snow Labs 5.2.7 Library released with the following pre-installed and r
 
 
 ## 5.2.6
-Release date: 2-4-2023
+Release date: 2-4-2024
 
 The John Snow Labs 5.2.6 Library released with the following pre-installed and recommended dependencies
 
@@ -152,7 +169,7 @@ The John Snow Labs 5.2.6 Library released with the following pre-installed and r
 
 
 ## 5.2.5
-Release date: 2-3-2023
+Release date: 2-3-2024
 
 The John Snow Labs 5.2.5 Library released with the following pre-installed and recommended dependencies
 
@@ -173,7 +190,7 @@ The John Snow Labs 5.2.5 Library released with the following pre-installed and r
 
 
 ## 5.2.4
-Release date: 2-1-2023
+Release date: 2-1-2024
 
 The John Snow Labs 5.2.4 Library released with the following pre-installed and recommended dependencies
 
@@ -192,7 +209,7 @@ The John Snow Labs 5.2.4 Library released with the following pre-installed and r
 
 
 ## 5.2.3
-Release date: 31-1-2023
+Release date: 31-1-2024
 
 The John Snow Labs 5.2.3 Library released with the following pre-installed and recommended dependencies
 
@@ -211,7 +228,7 @@ The John Snow Labs 5.2.3 Library released with the following pre-installed and r
 
 
 ## 5.2.2
-Release date: 22-1-2023
+Release date: 22-1-2024
 
 The John Snow Labs 5.2.2 Library released with the following pre-installed and recommended dependencies
 
@@ -228,7 +245,7 @@ The John Snow Labs 5.2.2 Library released with the following pre-installed and r
 | [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.1.2` |
 
 ## 5.2.1
-Release date: 20-1-2023
+Release date: 20-1-2024
 
 The John Snow Labs 5.2.1 Library released with the following pre-installed and recommended dependencies
 
@@ -247,7 +264,7 @@ The John Snow Labs 5.2.1 Library released with the following pre-installed and r
 
 
 ## 5.2.0
-Release date: 4-1-2023
+Release date: 4-1-2024
 
 The John Snow Labs 5.2.0 Library released with the following pre-installed and recommended dependencies
 

--- a/johnsnowlabs/finance.py
+++ b/johnsnowlabs/finance.py
@@ -10,9 +10,6 @@ try:
         from sparknlp_jsl.training import *
         from sparknlp_jsl.structured_deidentification import StructuredDeidentification
         from sparknlp_jsl.base import FeaturesAssembler
-        from sparknlp_jsl.annotator.windowed.windowed_sentence import (
-            WindowedSentenceModel,
-        )
         from sparknlp_jsl.finance.token_classification.ner.zero_shot_ner import ZeroShotNerModel
         from sparknlp_jsl.training_log_parser import ner_log_parser
 
@@ -112,6 +109,11 @@ try:
             TextMatcherInternalModel as TextMatcherModel,
             RegexMatcherInternal as RegexMatcher,
             RegexMatcherInternalModel as RegexMatcherModel,
+            AssertionMerger,
+            LightDeIdentification,
+            WindowedSentenceModel,
+            MultiChunk2Doc,
+            FewShotAssertionClassifierModel
         )
 
         from sparknlp_jsl.modelTracer import ModelTracer

--- a/johnsnowlabs/legal.py
+++ b/johnsnowlabs/legal.py
@@ -8,9 +8,6 @@ try:
     if try_import_lib("sparknlp_jsl") and try_import_lib("sparknlp"):
         from sparknlp_jsl.functions import *
         from sparknlp_jsl.training import *
-        from sparknlp_jsl.annotator.windowed.windowed_sentence import (
-            WindowedSentenceModel,
-        )
         from sparknlp_jsl.legal.token_classification.ner.zero_shot_ner import ZeroShotNerModel
         from sparknlp_jsl.training_log_parser import ner_log_parser
 
@@ -110,6 +107,11 @@ try:
             TextMatcherInternalModel as TextMatcherModel,
             RegexMatcherInternal as RegexMatcher,
             RegexMatcherInternalModel as RegexMatcherModel,
+            AssertionMerger,
+            LightDeIdentification,
+            WindowedSentenceModel,
+            MultiChunk2Doc,
+            FewShotAssertionClassifierModel
         )
         from sparknlp_jsl.modelTracer import ModelTracer
 

--- a/johnsnowlabs/medical.py
+++ b/johnsnowlabs/medical.py
@@ -12,9 +12,6 @@ try:
     if try_import_lib("sparknlp_jsl") and try_import_lib("sparknlp"):
         from sparknlp_jsl.functions import *
         from sparknlp_jsl.training import *
-        from sparknlp_jsl.annotator.windowed.windowed_sentence import (
-            WindowedSentenceModel,
-        )
         from sparknlp_jsl.annotator.ner.zero_shot_ner import ZeroShotNerModel
         from sparknlp_jsl.annotator import (
             GenericSVMClassifierApproach,
@@ -87,11 +84,18 @@ try:
             IOBTagger,
             DocumentFiltererByClassifier,
             Flattener,
+            AssertionMerger,
+            LightDeIdentification,
+            WindowedSentenceModel,
+            MultiChunk2Doc,
+            FewShotAssertionClassifierModel
         )
         from sparknlp_jsl.structured_deidentification import StructuredDeidentification
         from sparknlp_jsl.modelTracer import ModelTracer
         from sparknlp_jsl import training_log_parser, Deid
         from sparknlp_jsl.training_log_parser import ner_log_parser
+        from sparknlp_jsl.pipeline_output_parser import PipelineOutputParser
+        from sparknlp_jsl.updateModels import UpdateModels
 
         from sparknlp_jsl.base import FeaturesAssembler
 

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -12,7 +12,7 @@ from johnsnowlabs.utils.env_utils import (
 
 
 
-raw_version_jsl_lib = "5.3.3"
+raw_version_jsl_lib = "5.3.4"
 
 
 raw_version_nlp = "5.3.1"
@@ -23,11 +23,11 @@ raw_version_nlu = "5.3.0"
 raw_version_pyspark = "3.4.0"
 raw_version_nlp_display = "5.0"
 
-raw_version_medical = "5.3.0"
-raw_version_secret_medical = "5.3.0"
+raw_version_medical = "5.3.1"
+raw_version_secret_medical = "5.3.1"
 
-raw_version_secret_ocr = "5.3.0"
-raw_version_ocr = "5.3.0"
+raw_version_secret_ocr = "5.3.1"
+raw_version_ocr = "5.3.1"
 
 raw_version_pydantic = "1.10.11"
 

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -15,7 +15,7 @@ from johnsnowlabs.utils.env_utils import (
 raw_version_jsl_lib = "5.3.4"
 
 
-raw_version_nlp = "5.3.1"
+raw_version_nlp = "5.3.2"
 
 raw_version_nlu = "5.3.0"
 
@@ -23,8 +23,8 @@ raw_version_nlu = "5.3.0"
 raw_version_pyspark = "3.4.0"
 raw_version_nlp_display = "5.0"
 
-raw_version_medical = "5.3.1"
-raw_version_secret_medical = "5.3.1"
+raw_version_medical = "5.3.2"
+raw_version_secret_medical = "5.3.2"
 
 raw_version_secret_ocr = "5.3.1"
 raw_version_ocr = "5.3.1"

--- a/johnsnowlabs/utils/modelhub_markdown.py
+++ b/johnsnowlabs/utils/modelhub_markdown.py
@@ -7,9 +7,6 @@ import johnsnowlabs.utils.testing.test_settings
 from johnsnowlabs.utils.file_utils import path_tail
 from johnsnowlabs.utils.py_process import execute_py_script_string_as_new_proc
 
-Path(johnsnowlabs.utils.testing.test_settings.tmp_markdown_dir).mkdir(
-    exist_ok=True, parents=True
-)
 
 
 def get_py_snippet_from_modelhub(url):

--- a/johnsnowlabs/utils/py_process.py
+++ b/johnsnowlabs/utils/py_process.py
@@ -9,11 +9,6 @@ import pandas as pd
 import johnsnowlabs.utils.testing.test_settings
 from johnsnowlabs.utils.file_utils import str_to_file
 
-Path(johnsnowlabs.utils.testing.test_settings.tmp_markdown_dir).mkdir(
-    exist_ok=True, parents=True
-)
-
-
 def run_cmd_and_check_succ(
     args: List[str],
     log=True,
@@ -102,6 +97,10 @@ def execute_py_script_string_as_new_proc(
     use_i_py=False,
     add_prefix=True,
 ):
+    Path(johnsnowlabs.utils.testing.test_settings.tmp_markdown_dir).mkdir(
+        exist_ok=True, parents=True
+    )
+
     if file_name:
         out_path = f"{johnsnowlabs.utils.testing.test_settings.tmp_markdown_dir}/{file_name}_MD_TEST.py"
     else:


### PR DESCRIPTION
1- Bumped sparknlp and sparknlp_jsl to 532

2- Added new healthcare annotations to johnsnowlabs
- AssertionMerger
- LightDeIdentification
- MultiChunk2Doc
- FewShotAssertionClassifierModel

3- Added PipelineOutputParser & UpdateModels module

WARNING: need to change the base branch before merging