### PR TITLE
Update 2022-11-28-legclf_cuad_obligations_clause_en.md

### DIFF
--- a/docs/_posts/josejuanmartinez/2022-11-28-legclf_cuad_obligations_clause_en.md
+++ b/docs/_posts/josejuanmartinez/2022-11-28-legclf_cuad_obligations_clause_en.md
@@ -55,7 +55,7 @@ embeddings = nlp.BertSentenceEmbeddings.pretrained("sent_bert_base_cased", "en")
       .setInputCols("document") \
       .setOutputCol("sentence_embeddings")
 
-docClassifier = legal.ClassifierDLModel.pretrained("legclf_cuad_obligations_absolute_clause", "en", "legal/models")\
+docClassifier = legal.ClassifierDLModel.pretrained("legclf_cuad_obligations_clause", "en", "legal/models")\
     .setInputCols(["sentence_embeddings"])\
     .setOutputCol("category")
     


### PR DESCRIPTION
Example code was using the wrong pretrained model name in the pipeline.