### PR TITLE
Addition new healthcare annotations in v540

### DIFF
--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -16,6 +16,23 @@ sidebar:
 See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for detailed information on Release History and Features
 
 
+
+# 5.3.6
+Release date: 5-22-2024
+
+The John Snow Labs 5.3.5 Library released with the following pre-installed and recommended dependencies
+
+
+| Library                                                                                 | Version |
+|-----------------------------------------------------------------------------------------|---------|
+| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `5.3.2` |
+| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `5.3.2` |
+| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X` |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X` |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.3.2` |
+| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`   |
+| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `5.3.2` |
+| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0` |
 # 5.3.5
 Release date: 5-11-2024
 

--- a/johnsnowlabs/auto_install/databricks/install_utils.py
+++ b/johnsnowlabs/auto_install/databricks/install_utils.py
@@ -12,7 +12,7 @@ from johnsnowlabs.py_models.install_info import (
     RootInfo,
 )
 from johnsnowlabs.py_models.lib_version import LibVersion
-from johnsnowlabs.utils.env_utils import is_running_in_databricks
+from johnsnowlabs.utils.env_utils import is_running_in_databricks_runtime
 from .dbfs import *
 
 # https://pypi.org/project/databricks-api/
@@ -357,7 +357,7 @@ def install_jsl_suite_to_cluster(
         )
 
     # On databricks environment should restart current cluster to apply uninstalls and installations
-    if is_running_in_databricks():
+    if is_running_in_databricks_runtime():
         try:
             restart_cluster(db, cluster_id)
         except:

--- a/johnsnowlabs/finance.py
+++ b/johnsnowlabs/finance.py
@@ -113,7 +113,14 @@ try:
             LightDeIdentification,
             WindowedSentenceModel,
             MultiChunk2Doc,
-            FewShotAssertionClassifierModel
+            FewShotAssertionClassifierModel,
+            FewShotAssertionClassifierApproach,
+            FewShotAssertionSentenceConverter,
+            VectorDBApproach,
+            VectorDBModel,
+            VectorDBPostProcessor,
+            ContextSplitAssembler,
+            ContextualAssertion,
         )
 
         from sparknlp_jsl.modelTracer import ModelTracer

--- a/johnsnowlabs/finance.py
+++ b/johnsnowlabs/finance.py
@@ -116,8 +116,6 @@ try:
             FewShotAssertionClassifierModel,
             FewShotAssertionClassifierApproach,
             FewShotAssertionSentenceConverter,
-            VectorDBApproach,
-            VectorDBModel,
             VectorDBPostProcessor,
             ContextSplitAssembler,
             ContextualAssertion,

--- a/johnsnowlabs/legal.py
+++ b/johnsnowlabs/legal.py
@@ -111,7 +111,14 @@ try:
             LightDeIdentification,
             WindowedSentenceModel,
             MultiChunk2Doc,
-            FewShotAssertionClassifierModel
+            FewShotAssertionClassifierModel,
+            FewShotAssertionClassifierApproach,
+            FewShotAssertionSentenceConverter,
+            VectorDBApproach,
+            VectorDBModel,
+            VectorDBPostProcessor,
+            ContextSplitAssembler,
+            ContextualAssertion,
         )
         from sparknlp_jsl.modelTracer import ModelTracer
 

--- a/johnsnowlabs/legal.py
+++ b/johnsnowlabs/legal.py
@@ -114,8 +114,6 @@ try:
             FewShotAssertionClassifierModel,
             FewShotAssertionClassifierApproach,
             FewShotAssertionSentenceConverter,
-            VectorDBApproach,
-            VectorDBModel,
             VectorDBPostProcessor,
             ContextSplitAssembler,
             ContextualAssertion,

--- a/johnsnowlabs/medical.py
+++ b/johnsnowlabs/medical.py
@@ -91,8 +91,6 @@ try:
             FewShotAssertionClassifierModel,
             FewShotAssertionClassifierApproach,
             FewShotAssertionSentenceConverter,
-            VectorDBApproach,
-            VectorDBModel,
             VectorDBPostProcessor,
             ContextSplitAssembler,
             ContextualAssertion,
@@ -103,6 +101,7 @@ try:
         from sparknlp_jsl.training_log_parser import ner_log_parser
         from sparknlp_jsl.pipeline_output_parser import PipelineOutputParser
         from sparknlp_jsl.updateModels import UpdateModels
+        from sparknlp_jsl.llm import LLMLoader
 
         from sparknlp_jsl.base import FeaturesAssembler
 

--- a/johnsnowlabs/medical.py
+++ b/johnsnowlabs/medical.py
@@ -88,7 +88,14 @@ try:
             LightDeIdentification,
             WindowedSentenceModel,
             MultiChunk2Doc,
-            FewShotAssertionClassifierModel
+            FewShotAssertionClassifierModel,
+            FewShotAssertionClassifierApproach,
+            FewShotAssertionSentenceConverter,
+            VectorDBApproach,
+            VectorDBModel,
+            VectorDBPostProcessor,
+            ContextSplitAssembler,
+            ContextualAssertion,
         )
         from sparknlp_jsl.structured_deidentification import StructuredDeidentification
         from sparknlp_jsl.modelTracer import ModelTracer

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -15,7 +15,7 @@ from johnsnowlabs.utils.env_utils import (
 raw_version_jsl_lib = "5.3.6"
 
 
-raw_version_nlp = "5.3.2"
+raw_version_nlp = "5.4.0"
 
 raw_version_nlu = "5.3.2"
 
@@ -23,8 +23,8 @@ raw_version_nlu = "5.3.2"
 raw_version_pyspark = "3.4.0"
 raw_version_nlp_display = "5.0"
 
-raw_version_medical = "5.3.2"
-raw_version_secret_medical = "5.3.2"
+raw_version_medical = "5.4.0"
+raw_version_secret_medical = "5.4.0"
 
 raw_version_secret_ocr = "5.3.2"
 raw_version_ocr = "5.3.2"

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -3,7 +3,7 @@ from os.path import expanduser
 
 from johnsnowlabs.utils.env_utils import (
     env_required_license,
-    is_running_in_databricks,
+    is_running_in_databricks_runtime,
     is_running_in_emr,
     set_py4j_logger_to_error_on_databricks,
 )
@@ -37,7 +37,7 @@ enforce_secret_on_version = False
 enforce_versions = True
 
 # Environment
-on_databricks = is_running_in_databricks()
+on_databricks = is_running_in_databricks_runtime()
 on_emr = is_running_in_emr()
 license_required = env_required_license()
 

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -12,12 +12,12 @@ from johnsnowlabs.utils.env_utils import (
 
 
 
-raw_version_jsl_lib = "5.3.5"
+raw_version_jsl_lib = "5.3.6"
 
 
 raw_version_nlp = "5.3.2"
 
-raw_version_nlu = "5.3.1"
+raw_version_nlu = "5.3.2"
 
 
 raw_version_pyspark = "3.4.0"

--- a/johnsnowlabs/utils/env_utils.py
+++ b/johnsnowlabs/utils/env_utils.py
@@ -103,14 +103,10 @@ def is_running_in_emr():
     return False
 
 
-def is_running_in_databricks():
-    """Check if the currently running Python Process is running in Databricks or not
-    If any Environment Variable name contains 'DATABRICKS' this will return True, otherwise False
+def is_running_in_databricks_runtime():
+    """ Check if the currently running Python Process is running in Databricks runtime or not
     """
-    for k in os.environ.keys():
-        if "DATABRICKS" in k:
-            return True
-    return False
+    return "DATABRICKS_RUNTIME_VERSION" in os.environ
 
 
 def env_required_license():


### PR DESCRIPTION
bump spark-nlp to 5.4.0
bump spark-nlp-jsl to 5.4.0
Add new healthcare annotators:
- FewShotAssertionClassifierModel,
- FewShotAssertionClassifierApproach,
- FewShotAssertionSentenceConverter,
- VectorDBPostProcessor,
- ContextSplitAssembler,
- ContextualAssertion

Note: Change the base branch