### PR TITLE
spark-nlp-jsl==5.5.0 requirements 

### DIFF
--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -15,6 +15,25 @@ sidebar:
 
 See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for detailed information on Release History and Features
 
+
+## 5.4.5
+Release date: 9-27-2024
+
+The John Snow Labs 5.4.5 Library released with the following pre-installed and recommended dependencies
+
+{:.table-model-big}
+| Library                                                                                 | Version    |
+|-----------------------------------------------------------------------------------------|------------|
+| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `5.4.1`    |
+| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `5.4.1`    |
+| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1` |
+| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
+| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `5.4.1`    |
+| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |
+
+
 ## 5.4.4
 Release date: 8-27-2024
 

--- a/johnsnowlabs/finance.py
+++ b/johnsnowlabs/finance.py
@@ -123,6 +123,8 @@ try:
             LargeFewShotClassifierModel,
             Mapper2Chunk,
             DocumentFiltererByNER,
+            REChunkMerger,
+            ContextualEntityFilterer,
         )
 
         from sparknlp_jsl.modelTracer import ModelTracer

--- a/johnsnowlabs/legal.py
+++ b/johnsnowlabs/legal.py
@@ -121,6 +121,8 @@ try:
             LargeFewShotClassifierModel,
             Mapper2Chunk,
             DocumentFiltererByNER,
+            REChunkMerger,
+            ContextualEntityFilterer,
         )
         from sparknlp_jsl.modelTracer import ModelTracer
         from sparknlp_jsl.pipeline_tracer import PipelineTracer

--- a/johnsnowlabs/medical.py
+++ b/johnsnowlabs/medical.py
@@ -98,6 +98,8 @@ try:
             LargeFewShotClassifierModel,
             Mapper2Chunk,
             DocumentFiltererByNER,
+            REChunkMerger,
+            ContextualEntityFilterer,
         )
         from sparknlp_jsl.structured_deidentification import StructuredDeidentification
         from sparknlp_jsl.text_to_documents_columns import TextToDocumentsColumns
@@ -130,6 +132,7 @@ try:
             TextMatcherInternalModel as TextMatcherModel,
             RegexMatcherInternal as RegexMatcher,
             RegexMatcherInternalModel as RegexMatcherModel,
+            MedicalLLM as AutoGGUFModel,
         )
         from sparknlp_jsl.compatibility import Compatibility
         from sparknlp_jsl.pretrained import InternalResourceDownloader

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -10,11 +10,11 @@ from johnsnowlabs.utils.env_utils import (
 
 # These versions are used for auto-installs and version  checks
 
-raw_version_jsl_lib = "5.4.4"
+raw_version_jsl_lib = "5.4.5"
 
 raw_version_nlp = "5.4.1"
 
-raw_version_nlu = "5.4.1rc1"
+raw_version_nlu = "5.4.1"
 
 
 raw_version_pyspark = "3.4.0"
@@ -23,8 +23,8 @@ raw_version_nlp_display = "5.0"
 raw_version_medical = "5.4.1"
 raw_version_secret_medical = "5.4.1"
 
-raw_version_secret_ocr = "5.4.0"
-raw_version_ocr = "5.4.0"
+raw_version_secret_ocr = "5.4.1"
+raw_version_ocr = "5.4.1"
 
 raw_version_pydantic = "1.10.11"
 

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -12,7 +12,7 @@ from johnsnowlabs.utils.env_utils import (
 
 raw_version_jsl_lib = "5.4.5"
 
-raw_version_nlp = "5.4.1"
+raw_version_nlp = "5.5.0"
 
 raw_version_nlu = "5.4.1"
 
@@ -20,8 +20,8 @@ raw_version_nlu = "5.4.1"
 raw_version_pyspark = "3.4.0"
 raw_version_nlp_display = "5.0"
 
-raw_version_medical = "5.4.1"
-raw_version_secret_medical = "5.4.1"
+raw_version_medical = "5.5.0"
+raw_version_secret_medical = "5.5.0"
 
 raw_version_secret_ocr = "5.4.1"
 raw_version_ocr = "5.4.1"


### PR DESCRIPTION
1. Bump versions:
- spark-nlp==5.5.0
- spark-nlp-jsl==5.5.0

2. Add new annotators:
- REChunkMerger,
- ContextualEntityFilterer,
- MedicalLLM as AutoGGUFModel

NOTE: change the base branch before the merge