### PR TITLE
add PAYG license fetch for API call

### DIFF
--- a/johnsnowlabs/utils/my_jsl_api.py
+++ b/johnsnowlabs/utils/my_jsl_api.py
@@ -166,7 +166,7 @@ def get_user_lib_secrets(access_token):
 
 def get_user_licenses(access_token):
     licenses_query = """query LicensesQuery {
-  licenses(isValid: true, platforms: ["Airgap", "Floating"]) {
+  licenses(isValid: true, platforms: ["Airgap", "Floating", "PAYG"]) {
     edges {
       node {
         id


### PR DESCRIPTION
Fix bug causing browser based install to fail if you only have PAYG licenses in your my.jsl account