### PR TITLE
Release/554

### DIFF
--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -17,6 +17,24 @@ See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for
 
 
 
+## 5.5.4
+Release date: 1-30-2025
+
+The John Snow Labs 5.5.2 Library released with the following pre-installed and recommended dependencies
+
+{:.table-model-big}
+| Library                                                                                 | Version    |
+|-----------------------------------------------------------------------------------------|------------|
+| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `5.5.0`    |
+| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `5.5.2`    |
+| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1` |
+| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
+| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `5.5.2`    |
+| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |
+
+
 
 ## 5.5.3
 Release date: 1-20-2025

--- a/johnsnowlabs/abstract_base/pydantic_model.py
+++ b/johnsnowlabs/abstract_base/pydantic_model.py
@@ -17,7 +17,7 @@ class WritableBaseModel(BaseModel):
         with open(path, "w", encoding="utf8") as json_file:
             if "indent" not in kwargs:
                 kwargs["indent"] = settings.json_indent
-            json_file.write(self.json(*args, **kwargs))
+            json_file.write(self.model_dump_json(*args, **kwargs))
 
     class Config:
         arbitrary_types_allowed = True

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -10,7 +10,7 @@ from johnsnowlabs.utils.env_utils import (
 
 # These versions are used for auto-installs and version  checks
 
-raw_version_jsl_lib = "5.5.3"
+raw_version_jsl_lib = "5.5.4"
 
 raw_version_nlp = "5.5.2"
 
@@ -23,8 +23,8 @@ raw_version_nlp_display = "5.0"
 raw_version_medical = "5.5.2"
 raw_version_secret_medical = "5.5.2"
 
-raw_version_secret_ocr = "5.4.2"
-raw_version_ocr = "5.4.2"
+raw_version_secret_ocr = "5.5.0"
+raw_version_ocr = "5.5.0"
 
 raw_version_pydantic = "2"
 

--- a/johnsnowlabs/utils/my_jsl_api.py
+++ b/johnsnowlabs/utils/my_jsl_api.py
@@ -166,7 +166,7 @@ def get_user_lib_secrets(access_token):
 
 def get_user_licenses(access_token):
     licenses_query = """query LicensesQuery {
-  licenses(isValid: true, platforms: ["Airgap", "Floating"]) {
+  licenses(isValid: true, platforms: ["Airgap", "Floating", "PAYG"]) {
     edges {
       node {
         id


### PR DESCRIPTION
- Bump visual NLP to 5.5.0
- Fix bug causing browser based install to fail if you only have PAYG licenses in your my.jsl account