### PR TITLE
Release/555

### DIFF
--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -17,10 +17,29 @@ See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for
 
 
 
+## 5.5.5
+Release date: 3-14-2025
+
+The John Snow Labs 5.5.5 Library released with the following pre-installed and recommended dependencies
+
+{:.table-model-big}
+| Library                                                                                 | Version    |
+|-----------------------------------------------------------------------------------------|------------|
+| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `5.5.0`    |
+| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `5.5.3`    |
+| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1` |
+| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
+| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `5.5.3`    |
+| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |
+
+
+
 ## 5.5.4
 Release date: 1-30-2025
 
-The John Snow Labs 5.5.2 Library released with the following pre-installed and recommended dependencies
+The John Snow Labs 5.5.4 Library released with the following pre-installed and recommended dependencies
 
 {:.table-model-big}
 | Library                                                                                 | Version    |
@@ -39,7 +58,7 @@ The John Snow Labs 5.5.2 Library released with the following pre-installed and r
 ## 5.5.3
 Release date: 1-20-2025
 
-The John Snow Labs 5.5.2 Library released with the following pre-installed and recommended dependencies
+The John Snow Labs 5.5.3 Library released with the following pre-installed and recommended dependencies
 
 {:.table-model-big}
 | Library                                                                                 | Version    |

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -10,9 +10,9 @@ from johnsnowlabs.utils.env_utils import (
 
 # These versions are used for auto-installs and version  checks
 
-raw_version_jsl_lib = "5.5.4"
+raw_version_jsl_lib = "5.5.5"
 
-raw_version_nlp = "5.5.2"
+raw_version_nlp = "5.5.3"
 
 raw_version_nlu = "5.4.1"
 
@@ -20,8 +20,8 @@ raw_version_nlu = "5.4.1"
 raw_version_pyspark = "3.4.0"
 raw_version_nlp_display = "5.0"
 
-raw_version_medical = "5.5.2"
-raw_version_secret_medical = "5.5.2"
+raw_version_medical = "5.5.3"
+raw_version_secret_medical = "5.5.3"
 
 raw_version_secret_ocr = "5.5.0"
 raw_version_ocr = "5.5.0"

--- a/setup_johnsnowlabs.py
+++ b/setup_johnsnowlabs.py
@@ -43,9 +43,11 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="Spark NLP OCR Finance Legal Medical John Snow Labs  ",
     packages=find_packages(exclude=["test*", "tmp*"]),  # exclude=['test']

--- a/setup_johnsnowlabs_for_databricks.py
+++ b/setup_johnsnowlabs_for_databricks.py
@@ -42,9 +42,11 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="Spark NLP OCR Finance Legal Medical John Snow Labs  ",
     packages=find_packages(exclude=["test*", "tmp*"]),  # exclude=['test']


### PR DESCRIPTION
The John Snow Labs 5.5.5 Library released with the following pre-installed and recommended dependencies

| Library                                                                                 | Version    |
|-----------------------------------------------------------------------------------------|------------|
| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `5.5.0`    |
| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `5.5.3`    |
| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1` |
| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `5.5.3`    |
| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |