### PR TITLE
release 6.0.2 web doc updated.

### DIFF
--- a/docs/en/licensed_annotator_entries/DeIdentification.md
+++ b/docs/en/licensed_annotator_entries/DeIdentification.md
@@ -25,6 +25,8 @@ Mask:
 - entity_labels: Mask with the entity type of that chunk. (default)
 - same_length_chars: Mask the deid entities with same length of asterix ( * ) with brackets ( [ , ] ) on both end.
 - fixed_length_chars: Mask the deid entities with a fixed length of asterix ( * ). The length is setting up using the setFixedMaskLength() method.
+- same_length_chars_without_brackets: masks entities with asterisks of the same length without square brackets.
+- entity_labels_without_brackets: replaces entities with their label without square brackets.
 
 Obfuscation: replace sensetive entities with random values of the same type.
 
@@ -61,7 +63,11 @@ Parameters:
 
 - `maskingPolicy`: (Param[String])
 Select the masking policy:
-same_length_chars: Replace the obfuscated entity with a masking sequence composed of asterisks and surrounding squared brackets, being the total length of the masking sequence of the same length as the original sequence. Example, Smith -> [***]. If the entity is less than 3 chars (like Jo, or 5), asterisks without brackets will be returned. entity_labels: Replace the values with the corresponding entity labels. fixed_length_chars: Replace the obfuscated entity with a masking sequence composed of a fixed number of asterisks.
+same_length_chars: Replace the obfuscated entity with a masking sequence composed of asterisks and surrounding squared brackets, being the total length of the masking sequence of the same length as the original sequence. Example, Smith -> [***]. If the entity is less than 3 chars (like Jo, or 5), asterisks without brackets will be returned. 
+entity_labels: Replace the values with the corresponding entity labels.
+fixed_length_chars: Replace the obfuscated entity with a masking sequence composed of a fixed number of asterisks.
+same_length_chars_without_brackets: masks entities with asterisks of the same length without square brackets. 
+entity_labels_without_brackets: replaces entities with their label without square brackets.
 
 - `minYear`: (IntParam) Minimum year to use when converting date to year
 
@@ -149,6 +155,34 @@ Default: `""` (empty string, meaning no grouping)
 This function is useful in de-identification pipelines where certain entity labels
 like "NAME" or "DATE" may be missing in some rows and need to be filled from other
 rows within the same group.
+
+-`geoConsistency`: (BooleanParam) Sets whether to enforce consistent obfuscation across geographical entities:
+state, city, street, zip and phone.
+This parameter enables intelligent geographical entity obfuscation that maintains
+realistic relationships between different geographic components.
+When enabled, the system ensures that obfuscated addresses form coherent, valid combinations
+rather than random replacements. Default: False
+
+-`countryObfuscation`: (BooleanParam) Whether to obfuscate country entities or not. If True, the country entities will be obfuscated. Default: False.
+
+- `additionalDateFormats`: (Param[String]) Additional date formats to be considered during date obfuscation.
+This allows users to specify custom date formats in addition to the default date formats. Default: [].
+
+- `selectiveObfuscateRefSource`: Dict[str, str]
+A dictionary of entity names to their obfuscation modes.
+This is used to selectively apply different obfuscation methods to specific entities.
+The keys are entity names and the values are the obfuscation sources.
+If an entity is not specified in this map, the `obfuscateRefSource` param is used to determine the obfuscation source.
+Possible values in dict for the obfuscation source are: 'custom', 'faker', 'both', 'file'.
+
+- `staticObfuscationPairs`: static obfuscation pairs is used to set static obfuscation pairs that will be used for de-identification.
+Each pair should contain three elements: original, entity type, and fake.
+The pairs must have exactly 3 elements: [original, entityType, fake].
+
+- `staticObfuscationPairsResource`: allows loading obfuscation triplets from an external file (e.g., CSV). Supports custom delimiter through the options parameter.
+
+
+
 
 
 To create a configured DeIdentificationModel, please see the example of DeIdentification.

--- a/docs/en/licensed_annotator_entries/LightDeidentification.md
+++ b/docs/en/licensed_annotator_entries/LightDeidentification.md
@@ -56,11 +56,11 @@ Parameters:
   you can reply to an execution several times with the same output.
 
 - `maskingPolicy` *(str)*:  Select the masking policy:
-  same_length_chars: Replace the obfuscated entity with a masking sequence composed of asterisks and surrounding squared brackets, being the total length of the masking sequence of the same length as the original sequence.
-  Example, Smith -> [***].
-  If the entity is less than 3 chars (like Jo, or 5), asterisks without brackets will be returned.
-  entity_labels: Replace the values with the corresponding entity labels.
-  fixed_length_chars: Replace the obfuscated entity with a masking sequence composed of a fixed number of asterisk.
+entity_labels: Mask with the entity type of that chunk. (default)
+same_length_chars: Mask the deid entities with same length of asterix ( * ) with brackets ( [ , ] ) on both end.
+fixed_length_chars: Mask the deid entities with a fixed length of asterix ( * ). The length is setting up using the setFixedMaskLength() method.
+same_length_chars_without_brackets: masks entities with asterisks of the same length without square brackets.
+entity_labels_without_brackets: replaces entities with their label without square brackets.
 
 - `fixedMaskLength` *(Int)*:  The length of the masking sequence in case of fixed_length_chars masking policy.
 
@@ -105,6 +105,29 @@ For example, if "John Smith" is obfuscated as "Liam Brown", then:
   ensuring consistency in name transformation.
 
 Default: True
+
+-`geoConsistency`: (BooleanParam) Sets whether to enforce consistent obfuscation across geographical entities:
+state, city, street, zip and phone.
+This parameter enables intelligent geographical entity obfuscation that maintains
+realistic relationships between different geographic components.
+When enabled, the system ensures that obfuscated addresses form coherent, valid combinations
+rather than random replacements. Default: False
+
+-`countryObfuscation`: (BooleanParam) Whether to obfuscate country entities or not. If True, the country entities will be obfuscated. Default: False.
+
+- `additionalDateFormats`: (Param[String]) Additional date formats to be considered during date obfuscation.
+  This allows users to specify custom date formats in addition to the default date formats. Default: [].
+
+- `selectiveObfuscateRefSource`: Dict[str, str]
+  A dictionary of entity names to their obfuscation modes.
+  This is used to selectively apply different obfuscation methods to specific entities.
+  The keys are entity names and the values are the obfuscation sources.
+  If an entity is not specified in this map, the `obfuscateRefSource` param is used to determine the obfuscation source.
+  Possible values in dict for the obfuscation source are: 'custom', 'faker', 'both', 'file'.
+
+- `staticObfuscationPairs`: static obfuscation pairs is used to set static obfuscation pairs that will be used for de-identification.
+  Each pair should contain three elements: original, entity type, and fake.
+  The pairs must have exactly 3 elements: [original, entityType, fake].
 
 
 {%- endcapture -%}

--- a/docs/en/licensed_annotator_entries/MetadataAnnotationConverter.md
+++ b/docs/en/licensed_annotator_entries/MetadataAnnotationConverter.md
@@ -1,0 +1,132 @@
+{%- capture title -%}
+MetadataAnnotationConverter
+{%- endcapture -%}
+
+{%- capture title_with_article -%}
+{%- endcapture -%}
+
+{%- capture model -%}
+model
+{%- endcapture -%}
+
+{%- capture model_description -%}
+Converts metadata fields in annotations into actual begin, end, or result values.
+
+`MetadataAnnotationConverter` enables users to override fields in Spark NLP annotations using
+values from their `metadata` dictionary. This is especially useful when metadata contains normalized
+values, corrected character offsets, or alternative representations of the entity or phrase.
+
+The transformation is handled on the Scala side and is compatible with Spark NLP pipelines.
+
+Parameters:
+
+- `inputType`: Type of the input annotation (e.g., "chunk", "token").
+- `resultField`: Name of the metadata key to override the `result` value.
+- `beginField`: Name of the metadata key to override the `begin` offset.
+- `endField`: Name of the metadata key to override the `end` offset.
+
+
+{%- endcapture -%}
+
+
+{%- capture model_input_anno -%}
+ANY
+{%- endcapture -%}
+
+{%- capture model_output_anno -%}
+ANY
+{%- endcapture -%}
+
+{%- capture model_python_medical -%}
+from johnsnowlabs import nlp, medical
+from sparknlp_jsl.annotator import AnnotationConverter
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = SentenceDetectorDLModel\
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models") \
+    .setInputCols(["document"]) \
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+text_matcher = TextMatcherInternal()\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("matched_text")\
+    .setEntities("./test-phrases.txt")\
+    .setEnableLemmatizer(True) \
+    .setEnableStemmer(True) \
+    .setCleanStopWords(True) \
+    .setBuildFromTokens(False)\
+    .setReturnChunks("original")\
+
+metadata_annotation_converter = MetadataAnnotationConverter()\
+    .setInputCols("matched_text")\
+    .setInputType("chunk") \
+    .setResultField("original_or_matched") \
+    .setOutputCol("new_chunk")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("embeddings")
+
+clinical_assertion_dl = AssertionDLModel.pretrained("assertion_dl", "en", "clinical/models") \
+    .setInputCols(["sentence", "new_chunk", "embeddings"]) \
+    .setOutputCol("assertion_dl")\
+
+
+text_matcher_pipeline= Pipeline(
+    stages=[
+        document_assembler,
+        sentence_detector,
+        tokenizer,
+        word_embeddings,
+        text_matcher,
+        metadata_annotation_converter,
+        clinical_assertion_dl
+])
+
+text_matcher_model = text_matcher_pipeline.fit(empty_data)
+text_matcher_result_df = text_matcher_model.transform(data)
+
+
+
+
+# result
+
++------+-----+---+----------------------------+
+|entity|begin|end|result                      |
++------+-----+---+----------------------------+
+|entity|69   |99 |evaluation psychiatric state|
+|entity|52   |60 |stressor                    |
+|entity|114  |132|difficulty sleep            |
++------+-----+---+----------------------------+
+
+
+{%- endcapture -%}
+
+
+
+{%- capture model_api_link -%}
+[MetadataAnnotationConverter](https://nlp.johnsnowlabs.com/licensed/api/com/johnsnowlabs/nlp/annotators/MetadataAnnotationConverter.html)
+{%- endcapture -%}
+{%- capture model_python_api_link -%}
+
+[MetadataAnnotationConverter](https://nlp.johnsnowlabs.com/licensed/api/python/reference/autosummary/sparknlp_jsl/annotator/metadata_annotation_converter/index.html)
+{%- endcapture -%}
+
+
+{% include templates/licensed_approach_model_medical_fin_leg_template.md
+title=title
+model=model
+model_description=model_description
+model_input_anno=model_input_anno
+model_output_anno=model_output_anno
+model_python_medical=model_python_medical
+model_api_link=model_api_link
+model_python_api_link=model_python_api_link
+%}

--- a/docs/en/licensed_annotator_entries/TextMatcherInternal.md
+++ b/docs/en/licensed_annotator_entries/TextMatcherInternal.md
@@ -11,22 +11,46 @@ This annotator match exact phrases provided in a file against a Document.
 
 Parametres:
 
-- `setEntities` *(str)*: Sets the external resource for the entities.
+- `entities` *(str)*: external resource for the entities.
         path : str
             Path to the external resource
         read_as : str, optional
             How to read the resource, by default ReadAs.TEXT
         options : dict, optional
             Options for reading the resource, by default {"format": "text"}
-- `setCaseSensitive` *(Boolean)*: Sets whether to match regardless of case. (Default: True)
+- `caseSensitive` *(Boolean)*: whether to match regardless of case. (Default: True)
 
-- `setMergeOverlapping` *(Boolean)*: Sets whether to merge overlapping matched chunks. (Default: False)
+- `mergeOverlapping` *(Boolean)*: whether to merge overlapping matched chunks. (Default: False)
 
-- `setEntityValue` *(str)*: Sets the value for the entity metadata field. If any entity value isn't set in the file, we need to set it for the entity value.
+- `entityValue` *(str)*: value for the entity metadata field. If any entity value isn't set in the file, we need to set it for the entity value.
 
-- `setBuildFromTokens` *(Boolean)*: Sets whether the TextMatcherInternal should take the CHUNK from TOKEN.
+- `buildFromTokens` *(Boolean)*: whether the TextMatcherInternal should take the CHUNK from TOKEN.
 
-- `setDelimiter` *(str)*: Sets value for the delimiter between Phrase, Entity.
+- `delimiter` *(str)*: value for the delimiter between Phrase, Entity.
+
+- `enableLemmatizer` *(Boolean)*: whether to enable lemmatization. (Default: False)
+
+- `enableStemmer` *(Boolean)*: whether to enable stemming. (Default: False)
+
+- `cleanStopWords` *(Boolean)*: whether to clean stop words. (Default: False)
+
+- `shuffleEntitySubTokens` *(Boolean)*: whether to use permutations of entity phrase tokens to improve matching. (Default: False)
+
+- `safeKeywords` *(List[str])*: list of critical terms that should never be removed, even if they are stop words or noise words.
+
+- `excludePunctuation` *(Boolean)*: whether to remove all punctuation characters during matching. (Default: False)
+
+- `cleanKeywords` *(List[str])*: list of domain-specific noise words to be removed from entities.
+
+- `excludeRegexPatterns` *(List[str])*: list of regex patterns; if a matched chunk fits one of these patterns, it will be discarded.
+
+- `returnChunks` *(str)*: whether to return the matched phrase in its original form or normalized version. Accepted values: `"original"`, `"matched"`.
+
+- `skipMatcherAugmentation` *(Boolean)*: whether to disable augmentation on the matcher side (e.g., token permutations). (Default: False)
+
+- `skipSourceTextAugmentation` *(Boolean)*: whether to disable augmentation on the source text side. (Default: False)
+
+
 
 See [Spark NLP Workshop](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/40.Rule_Based_Entity_Matchers.ipynb) for more examples of usage.
 {%- endcapture -%}
@@ -159,6 +183,10 @@ val result = matcherModel.transform(data)
 [TextMatcherInternal](https://nlp.johnsnowlabs.com/licensed/api/python/reference/autosummary/sparknlp_jsl/annotator/matcher/text_matcher_internal/index.html)
 {%- endcapture -%}
 
+{%- capture model_notebook_link -%}
+[TextMatcherInternalNotebook](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/40.1.Text_Matcher_Internal.ipynb)
+{%- endcapture -%}
+
 {% include templates/licensed_approach_model_medical_fin_leg_template.md
 title=title
 model=model
@@ -169,4 +197,6 @@ model_python_medical=model_python_medical
 model_scala_medical=model_scala_medical
 model_api_link=model_api_link
 model_python_api_link=model_python_api_link
+model_notebook_link=model_notebook_link
+
 %}

--- a/docs/en/licensed_annotators.md
+++ b/docs/en/licensed_annotators.md
@@ -90,6 +90,7 @@ Check out the [Spark NLP Annotators page](https://nlp.johnsnowlabs.com/docs/en/a
 {% include templates/licensed_table_entry.md  name="LLMLoader" summary="LLMLoader is designed to interact with a LLMs that are converted into gguf format. This module allows using John Snow Labs' licensed LLMs at various sizes that are finetuned on medical context for certain tasks."%}
 {% include templates/licensed_table_entry.md  name="Mapper2Chunk" summary="This annotator converts 'LABELED_DEPENDENCY' type annotations coming from ChunkMapper into 'CHUNK' type to create new chunk-type column"%}
 {% include templates/licensed_table_entry.md  name="MedicalLLM" summary="MedicalLLM was designed to load and run large language models (LLMs) in GGUF format with scalable performance."%}
+{% include templates/licensed_table_entry.md  name="MetadataAnnotationConverter" summary="Converts metadata fields in annotations into actual begin, end, or result values."%}
 {% include templates/licensed_table_entry.md  name="MultiChunk2Doc" summary="Merges a given chunks to create a document."%}
 {% include templates/licensed_table_entry.md  name="NameChunkObfuscator" summary="This annotator allows to transform a dataset with an Input Annotation of type CHUNK, into its obfuscated version of by obfuscating the given CHUNKS."%}
 {% include templates/licensed_table_entry.md  name="NerChunker" summary="Extracts phrases that fits into a known pattern using the NER tags."%}

--- a/docs/en/utility_helper_modules.md
+++ b/docs/en/utility_helper_modules.md
@@ -564,6 +564,12 @@ For example, if "John Smith" is obfuscated as "Liam Brown", then:
 - When the full name "John Smith" appears, it will be replaced with "Liam Brown"
 - When "John" or "Smith" appear individually, they will still be obfuscated as "Liam" and "Brown" respectively,
 ensuring consistency in name transformation. Default: True
+- `selectiveObfuscateRefSource`: Dict[str, str]
+  A dictionary of entity names to their obfuscation modes.
+  This is used to selectively apply different obfuscation methods to specific entities.
+  The keys are entity names and the values are the obfuscation sources.
+  If an entity is not specified in this map, the `obfuscateRefSource` param is used to determine the obfuscation source.
+  Possible values in dict for the obfuscation source are: 'custom', 'faker', 'both', 'file'.
 
 
 Functions :


### PR DESCRIPTION
The documentation for the Spark NLP for Healthcare 6.0.2 release has been updated on the official website.