### PR TITLE
John Snow Labs 6.0.4 Release

### DIFF
--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -16,6 +16,23 @@ sidebar:
 See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for detailed information on Release History and Features
 
 
+## 6.0.4
+Release date: 7-26-2025
+
+The John Snow Labs 6.0.4 Library released with the following pre-installed and recommended dependencies
+
+{:.table-model-big}
+| Library                                                                                 | Version    |
+|-----------------------------------------------------------------------------------------|------------|
+| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `6.0.0`    |
+| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `6.0.4`    |
+| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1` |
+| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
+| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `6.0.4`    |
+| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |
+
 
 ## 6.0.3
 Release date: 6-12-2025

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -10,9 +10,9 @@ from johnsnowlabs.utils.env_utils import (
 
 # These versions are used for auto-installs and version  checks
 
-raw_version_jsl_lib = "6.0.3"
+raw_version_jsl_lib = "6.0.4"
 
-raw_version_nlp = "6.0.3"
+raw_version_nlp = "6.0.4"
 
 raw_version_nlu = "5.4.1"
 
@@ -20,8 +20,8 @@ raw_version_nlu = "5.4.1"
 raw_version_pyspark = "3.4.0"
 raw_version_nlp_display = "5.0"
 
-raw_version_medical = "6.0.3"
-raw_version_secret_medical = "6.0.3"
+raw_version_medical = "6.0.4"
+raw_version_secret_medical = "6.0.4"
 
 raw_version_secret_ocr = "6.0.0"
 raw_version_ocr = "6.0.0"


### PR DESCRIPTION
John Snow Labs 6.0.4 comes with the following upgrades:

- Bump Enterprise-NLP to 6.0.4
- Bump Spark-NLP to 6.0.4