### PR TITLE
Release 6.1.1

### DIFF
--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -17,7 +17,22 @@ See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for
 
 
 
+## 6.1.1
+Release date: 9-22-2025
 
+The John Snow Labs 6.1.1 Library released with the following pre-installed and recommended dependencies
+
+{:.table-model-big}
+| Library                                                                                 | Version    |
+|-----------------------------------------------------------------------------------------|------------|
+| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `6.1.0`    |
+| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `6.1.1`    |
+| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1`    |
+| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
+| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `6.1.3`    |
+| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |
 
 
 ## 6.1.0
@@ -31,8 +46,8 @@ The John Snow Labs 6.1.0 Library released with the following pre-installed and r
 | [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `6.1.0`    |
 | [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `6.1.0`    |
 | [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
-| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | clea`1.X.X`    |
-| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1` |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1`    |
 | [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
 | [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `6.1.1`    |
 | [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |

--- a/johnsnowlabs/medical.py
+++ b/johnsnowlabs/medical.py
@@ -140,7 +140,8 @@ try:
             RegexMatcherInternal as RegexMatcher,
             RegexMatcherInternalModel as RegexMatcherModel,
             MedicalLLM as AutoGGUFModel,
-            MedicalVisionLLM as AutoGGUFVisionModel
+            MedicalVisionLLM as AutoGGUFVisionModel,
+            MedicalNerDLGraphChecker as NerDLGraphChecker,
         )
         from sparknlp_jsl.compatibility import Compatibility
         from sparknlp_jsl.pretrained import InternalResourceDownloader

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -10,9 +10,9 @@ from johnsnowlabs.utils.env_utils import (
 
 # These versions are used for auto-installs and version  checks
 
-raw_version_jsl_lib = "6.1.0"
+raw_version_jsl_lib = "6.1.1"
 
-raw_version_nlp = "6.1.1"
+raw_version_nlp = "6.1.3"
 
 raw_version_nlu = "5.4.1"
 
@@ -20,8 +20,8 @@ raw_version_nlu = "5.4.1"
 raw_version_pyspark = "3.4.0"
 raw_version_nlp_display = "5.0"
 
-raw_version_medical = "6.1.0"
-raw_version_secret_medical = "6.1.0"
+raw_version_medical = "6.1.1"
+raw_version_secret_medical = "6.1.1"
 
 raw_version_secret_ocr = "6.1.0"
 raw_version_ocr = "6.1.0"


### PR DESCRIPTION
Release date: 9-22-2025

The John Snow Labs 6.1.1 Library released with the following pre-installed and recommended dependencies

| Library                                                                                 | Version    |
|-----------------------------------------------------------------------------------------|------------|
| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `6.1.0`    |
| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `6.1.1`    |
| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1`    |
| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `6.1.3`    |
| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |