### PR TITLE
Release/6.4.0

### DIFF
--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -17,7 +17,7 @@ See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for
 
 
 ## 6.4.0
-Release date: 26-4-2026
+Release date: 29-4-2026
 
 The John Snow Labs 6.4.0 Library released with the following pre-installed and recommended dependencies
 

--- a/docs/en/jsl/jsl_release_notes.md
+++ b/docs/en/jsl/jsl_release_notes.md
@@ -16,6 +16,26 @@ sidebar:
 See [Github Releases](https://github.com/JohnSnowLabs/johnsnowlabs/releases) for detailed information on Release History and Features
 
 
+## 6.4.0
+Release date: 26-4-2026
+
+The John Snow Labs 6.4.0 Library released with the following pre-installed and recommended dependencies
+
+{:.table-model-big}
+| Library                                                                                 | Version    |
+|-----------------------------------------------------------------------------------------|------------|
+| [Visual NLP](https://nlp.johnsnowlabs.com/docs/en/spark_ocr_versions/ocr_release_notes) | `6.4.0`    |
+| [Enterprise NLP](https://nlp.johnsnowlabs.com/docs/en/licensed_annotators)              | `6.4.0`    |
+| [Finance NLP](https://nlp.johnsnowlabs.com/docs/en/financial_release_notes)             | `1.X.X`    |
+| [Legal NLP](https://nlp.johnsnowlabs.com/docs/en/legal_release_notes)                   | `1.X.X`    |
+| [NLU](https://github.com/JohnSnowLabs/nlu/releases)                                     | `5.4.1`    |
+| [Spark-NLP-Display](https://sparknlp.org/docs/en/display)                               | `5.0`      |
+| [Spark-NLP](https://github.com/JohnSnowLabs/spark-nlp/releases/)                        | `6.4.0`    |
+| [Pyspark](https://spark.apache.org/docs/latest/api/python/)                             | `3.4.0`    |
+
+
+
+
 ## 6.3.0
 Release date: 1-4-2026
 

--- a/johnsnowlabs/medical.py
+++ b/johnsnowlabs/medical.py
@@ -107,7 +107,9 @@ try:
             FhirDeIdentification,
             AnnotationConverter,
             MetadataAnnotationConverter,
-            CdaDeIdentification
+            CdaDeIdentification,
+            PretrainedZeroShotMultiTask,
+            MultiAnnotationSplitter,
         )
         from sparknlp_jsl.structured_deidentification import StructuredDeidentification
         from sparknlp_jsl.text_to_documents_columns import TextToDocumentsColumns

--- a/johnsnowlabs/settings.py
+++ b/johnsnowlabs/settings.py
@@ -10,9 +10,9 @@ from johnsnowlabs.utils.env_utils import (
 
 # These versions are used for auto-installs and version  checks
 
-raw_version_jsl_lib = "6.3.0"
+raw_version_jsl_lib = "6.4.0"
 
-raw_version_nlp = "6.3.2"
+raw_version_nlp = "6.4.0"
 
 raw_version_nlu = "5.4.1"
 
@@ -20,11 +20,11 @@ raw_version_nlu = "5.4.1"
 raw_version_pyspark = "3.4.0"
 raw_version_nlp_display = "5.0"
 
-raw_version_medical = "6.3.0"
-raw_version_secret_medical = "6.3.0"
+raw_version_medical = "6.4.0"
+raw_version_secret_medical = "6.4.0"
 
-raw_version_secret_ocr = "6.3.0"
-raw_version_ocr = "6.3.0"
+raw_version_secret_ocr = "6.4.0"
+raw_version_ocr = "6.4.0"
 
 raw_version_pydantic = "2"
 


### PR DESCRIPTION
John Snow Labs 6.4.0 released with the following upgrades:

- Bump Enterprise NLP to 6.4.0
- Bump Visual NLP to 6.4.0
- Bump Spark NLP to 6.4.0
- Add PretrainedZeroShotMultiTask and MultiAnnotationSplitter to medical module