### PR TITLE
Add Medical VLM Workshop demos to Visual NLP demo pages

### DIFF
--- a/docs/demos/extract_handwritten_texts.md
+++ b/docs/demos/extract_handwritten_texts.md
@@ -20,6 +20,18 @@ data:
           activemenu: extract_handwritten_texts
       source: yes
       source: 
+        - title: Handwritten Prescription OCR and De-ID
+          id: vlm_handwritten_deid
+          image: 
+              src: /assets/images/Detect_Handwritten.svg
+          excerpt: Read handwritten medical prescriptions, de-identify PHI, and extract drug, dose and route linked to RxNorm. The hardest OCR task, on-prem.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/handwritten-deid
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/1.visual_deid.ipynb
         - title: Extract Signatures
           id: extract-signatures-new
           image: 

--- a/docs/demos/financial_document_understanding.md
+++ b/docs/demos/financial_document_understanding.md
@@ -21,6 +21,30 @@ data:
           activemenu: financial_document_understanding
       source: yes
       source: 
+        - title: Invoice Extraction and Duplicate Detection (VLM)
+          id: vlm_invoice_processing
+          image: 
+              src: /assets/images/Extract_entities_from_visual_documents.svg
+          excerpt: Extract vendor, line items and totals from invoices with duplicate detection. 99% vendor accuracy, ERP-ready JSON, fully on-prem.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/invoice-processing
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/9.invoice_expense_processing.ipynb
+        - title: Multilingual Receipt Processing
+          id: vlm_multilingual_receipts
+          image: 
+              src: /assets/images/Financial_Visual_NER_on_Receipts.svg
+          excerpt: Detect, translate and categorize expense receipts in 50+ languages with a hybrid policy-violation engine for alcohol and personal items.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/multilingual-receipts
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/9.invoice_expense_processing.ipynb
         - title: Classify Financial Documents 
           id: classify_financial_documents_using_spark_ocr 
           image: 

--- a/docs/demos/medical_files.md
+++ b/docs/demos/medical_files.md
@@ -21,6 +21,78 @@ data:
           activemenu: medical_files
       source: yes
       source: 
+        - title: Medical Document De-Identification (VLM)
+          id: vlm_visual_deid
+          image: 
+              src: /assets/images/Deidentify_PDF_documents.svg
+          excerpt: Redact PHI from scanned clinical documents with bounding-box precision using the JSL Vision OCR plus Spark NLP DEID pipeline. 100% PHI recall, fully on-prem.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/visual-deid
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/1.visual_deid.ipynb
+        - title: Medical Document Cross-Modal Search (RAG)
+          id: vlm_medical_rag
+          image: 
+              src: /assets/images/Answering_Medical_Questions.svg
+          excerpt: Search medical records by text, image, or both using JSL Vision cross-modal embeddings, with Spark NLP entity extraction and ICD-10, RxNorm and SNOMED coding.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/medical-rag
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/3.medical_rag.ipynb
+        - title: Dermatology Image Classification and Retrieval
+          id: vlm_dermatology_rag
+          image: 
+              src: /assets/images/Image_Classifier_in_Document_Images.svg
+          excerpt: Classify skin lesions (91% across 8 classes) and retrieve visually similar cases with ICD-10 coding, powered by JSL Vision image embeddings.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/dermatology-rag
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/4.dermatology_rag.ipynb
+        - title: Radiology Image Classification and Retrieval
+          id: vlm_radiology_rag
+          image: 
+              src: /assets/images/Detect_Anatomical_and_Observation_Entities_in_Chest_Radiology_Reports.svg
+          excerpt: Classify chest X-ray findings and body parts, extract radiology entities, and retrieve similar prior studies on-prem.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/radiology-rag
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/5.radiology_rag.ipynb
+        - title: Pathology Slide Classification and Retrieval
+          id: vlm_pathology_rag
+          image: 
+              src: /assets/images/Image_Classifier_in_Document_Images.svg
+          excerpt: Breast-cancer screening, tissue typing and WBC classification with ICD-O coding over a large histopathology image index.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/pathology-rag
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/6.pathology_rag.ipynb
+        - title: ECG Waveform Analysis
+          id: vlm_ecg_analysis
+          image: 
+              src: /assets/images/Multilabel_Text_Classification_for_Heart_Disease.svg
+          excerpt: Extract cardiac measurements (HR, PR, QRS, QT, Axis) from scanned paper ECGs and triage normal vs abnormal with JSL Vision Structured.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/ecg-analysis
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/7.ecg_waveform_analysis.ipynb
         - title: Dicom to Text
           id: dicom_to_text
           image: 

--- a/docs/demos/visual_document_understanding.md
+++ b/docs/demos/visual_document_understanding.md
@@ -21,6 +21,30 @@ data:
           activemenu: visual_document_understanding
       source: yes
       source: 
+        - title: Medical Document Mining and Routing
+          id: vlm_document_mining
+          image: 
+              src: /assets/images/Classify_visual_documents.svg
+          excerpt: Classify mixed document images by type, department and clinical urgency in under 5 seconds with enum-constrained JSL-MedVL extraction.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/document-mining
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/2.visual_document_mining_and_routing.ipynb
+        - title: Multilingual ID Document Extraction (KYC)
+          id: vlm_kyc_verification
+          image: 
+              src: /assets/images/Visual_NER_Key-Values_v2.svg
+          excerpt: Extract 21 structured fields from passports and national IDs across 10 countries and scripts, with automatic English transliteration. Fully on-prem.
+          actions:
+          - text: Live Demo
+            type: normal
+            url: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/kyc-verification
+          - text: Colab
+            type: blue_btn
+            url: https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/vlm-workshop/8.kyc_id_verification.ipynb
         - title: Visual Document Classification
           id: classify_visual_documents
           image: 


### PR DESCRIPTION
Adds the **11 Medical VLM Workshop** demos (JSL Vision / VLM series) as cards on the existing Visual NLP demo pages. Each card links to its **live demo** at `demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/<tab>` and its **Colab** notebook in `spark-nlp-workshop/tutorials/vlm-workshop`.

### Placement (by capability)
| Page | Demos added |
|------|-------------|
| **Medical Files Processing** | Visual De-ID, Medical RAG, Dermatology RAG, Radiology RAG, Pathology RAG, ECG Waveform Analysis |
| **Visual Document Understanding** | Document Mining & Routing, KYC ID Verification |
| **Financial Document Understanding** | Invoice Extraction & Duplicate Detection, Multilingual Receipt Processing |
| **Extract Handwritten Texts** | Handwritten Prescription OCR + De-ID |

### Notes
- Cards inserted at the **top** of each page's `source:` list so the new VLM demos are featured.
- All live-demo URLs verified (return 200); all Colab notebooks exist in the workshop folder.
- **Icons** reuse the closest existing `/assets/images` SVGs — design may want to swap dedicated icons later.
- YAML front matter validated for all 4 pages.

Live workshop: https://demo.johnsnowlabs.com/ocr/VLM_WORKSHOP/

🤖 Generated with [Claude Code](https://claude.com/claude-code)