### PR TITLE
2026-07-20-sbiobertresolve_HPO_en

### DIFF
--- a/docs/_posts/ozgurcaglayan1981/2026-07-20-bgeresolve_HPO_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-20-bgeresolve_HPO_en.md
@@ -1,0 +1,219 @@
+---
+layout: model
+title: Sentence Entity Resolver for HPO (bge_base_en_v1_5_onnx embeddings)
+author: John Snow Labs
+name: bgeresolve_HPO
+date: 2026-07-20
+tags: [en, entity_resolution, licensed, clinical, hpo, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps phenotypic abnormalities and medical terms associated with hereditary diseases to Human Phenotype Ontology (HPO) codes using `bge_base_en_v1_5_onnx` embeddings. It also returns associated codes from SNOMEDCT_US, UMLS, ORPHA, EPCC, and Fyler vocabularies in the `all_k_aux_labels` metadata field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_HPO_en_6.4.0_3.4_1784591893552.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_HPO_en_6.4.0_3.4_1784591893552.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["HP"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx","en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_HPO","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("hpo")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+])
+
+data = spark.createDataFrame([["She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["HP"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx","en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_HPO","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("hpo")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+])
+
+data = spark.createDataFrame([["She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("HP"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_HPO", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("hpo")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                  | entity   | hpo_code   | resolution                                        | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:---------------------------|:---------|:-----------|:--------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| tricuspid regurgitation    | HP       | HP:0005180 | tricuspid regurgitation [tricuspid regurgitation] | HP:0005180:::HP:0010446:::HP:0001702:::HP:0031651:::HP:0001653:::HP:0031444:::HP... | 0.0000:::0.1664:::0.1832:::0.1998:::0.2069:::0.2136:::0.2163:::0.2180:::0.2193::... | tricuspid regurgitation [tricuspid regurgitation]:::tricuspid stenosis [tricuspi... | Fyler:1161||SNOMEDCT_US:111287006||UMLS:C0040961:::EPCC:06.01.92||ICD-10:Q22.4||... |
+| aortic stenosis            | HP       | HP:0001650 | aortic stenosis [aortic valve stenosis]           | HP:0001650:::HP:0001682:::HP:0100545:::HP:0001691:::HP:0004381:::HP:0034350:::HP... | 0.0000:::0.1484:::0.1852:::0.1854:::0.1982:::0.2149:::0.2162:::0.2178:::0.2226::... | aortic stenosis [aortic valve stenosis]:::subvalvular aortic stenosis [subvalvul... | Fyler:1411||SNOMEDCT_US:60573004||UMLS:C0003507:::SNOMEDCT_US:204368006||UMLS:C0... |
+| mitral valve regurgitation | HP       | HP:0001653 | mitral valve regurgitation [mitral regurgitation] | HP:0001653:::HP:0001659:::HP:0010444:::HP:0034376:::HP:0005180:::HP:0001718:::HP... | 0.0000:::0.1583:::0.1617:::0.1639:::0.2041:::0.2129:::0.2305:::0.2416:::0.2463::... | mitral valve regurgitation [mitral regurgitation]:::aortic valve regurgitation [... | Fyler:1151||SNOMEDCT_US:48724000||UMLS:C0026266||UMLS:C3551535:::SNOMEDCT_US:602... |
+| hypertension               | HP       | HP:0000822 | hypertension [hypertension]                       | HP:0000822:::HP:0032263:::HP:0007906:::HP:0004421:::HP:0100817:::HP:0008071:::HP... | 0.0000:::0.1955:::0.2147:::0.2155:::0.2183:::0.2213:::0.2262:::0.2368:::0.2489::... | hypertension [hypertension]:::increased blood pressure [increased blood pressure... | SNOMEDCT_US:24184005||SNOMEDCT_US:38341003||UMLS:C0020538||UMLS:C0497247:::PMID:... |
+| dizzy spells               | HP       | HP:0002321 | dizzy spell [vertigo]                             | HP:0002321:::HP:0001279:::HP:0002121:::HP:4000033:::HP:0007185:::HP:0001250:::HP... | 0.0678:::0.2186:::0.2393:::0.2605:::0.2614:::0.2623:::0.2673:::0.2683:::0.2693::... | dizzy spell [vertigo]:::fainting spell [syncope]:::brief seizures with staring s... | SNOMEDCT_US:271789005||SNOMEDCT_US:399090003||SNOMEDCT_US:399153001||SNOMEDCT_US... |
+| bradycardia                | HP       | HP:0001662 | bradycardia [bradycardia]                         | HP:0001662:::HP:0001688:::HP:0046507:::HP:0002067:::HP:0001649:::HP:0031843:::HP... | 0.0000:::0.0689:::0.1928:::0.2124:::0.2437:::0.2500:::0.2578:::0.2592:::0.2638::... | bradycardia [bradycardia]:::sinus bradycardia [sinus bradycardia]:::bradypnea [b... | SNOMEDCT_US:48867003||UMLS:C0428977:::Fyler:7013||SNOMEDCT_US:49710005||UMLS:C00... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_HPO|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[hpo_code]|
+|Language:|en|
+|Size:|130.3 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-20-bgeresolve_HPO_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-20-bgeresolve_HPO_en.md
@@ -32,6 +32,7 @@ This model maps phenotypic abnormalities and medical terms associated with hered
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 documentAssembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-20-biolordresolve_HPO_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-20-biolordresolve_HPO_en.md
@@ -1,0 +1,219 @@
+---
+layout: model
+title: Sentence Entity Resolver for HPO (mpnet_embeddings_biolord_2023_c embeddings)
+author: John Snow Labs
+name: biolordresolve_HPO
+date: 2026-07-20
+tags: [en, entity_resolution, licensed, clinical, hpo, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps phenotypic abnormalities and medical terms associated with hereditary diseases to Human Phenotype Ontology (HPO) codes using `mpnet_embeddings_biolord_2023_c` embeddings. It also returns associated codes from SNOMEDCT_US, UMLS, ORPHA, EPCC, and Fyler vocabularies in the `all_k_aux_labels` metadata field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_HPO_en_6.4.0_3.4_1784590890095.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_HPO_en_6.4.0_3.4_1784590890095.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["HP"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c","en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_HPO","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("hpo")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+])
+
+data = spark.createDataFrame([["She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["HP"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c","en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_HPO","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("hpo")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+])
+
+data = spark.createDataFrame([["She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("HP"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_HPO", "en", "clinical/models")
+    .setInputCols(Array("embeddings"))
+    .setOutputCol("hpo")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                  | entity   | hpo_code   | resolution                                              | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:---------------------------|:---------|:-----------|:--------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| tricuspid regurgitation    | HP       | HP:0005180 | tricuspid valve regurgitation [tricuspid regurgitation] | HP:0005180:::HP:0001702:::HP:0001704:::HP:0031651:::HP:0034376:::HP:0030732:::HP... | 0.0318:::0.1703:::0.1997:::0.2508:::0.2583:::0.2671:::0.2762:::0.2863:::0.3045::... | tricuspid valve regurgitation [tricuspid regurgitation]:::abnormality of the tri... | Fyler:1161||SNOMEDCT_US:111287006||UMLS:C0040961:::EPCC:06.01.00||UMLS:C4025753:... |
+| aortic stenosis            | HP       | HP:0001650 | aortic stenosis [aortic valve stenosis]                 | HP:0001650:::HP:0001680:::HP:0001682:::HP:0012397:::HP:0001659:::HP:0001679:::HP... | 0.0229:::0.0903:::0.1693:::0.1763:::0.1966:::0.2117:::0.2125:::0.2189:::0.2232      | aortic stenosis [aortic valve stenosis]:::narrowing of the aorta [coarctation of... | Fyler:1411||SNOMEDCT_US:60573004||UMLS:C0003507:::PMID:23909637||SNOMEDCT_US:730... |
+| mitral valve regurgitation | HP       | HP:0001653 | mitral valve regurgitation [mitral regurgitation]       | HP:0001653:::HP:0001633:::HP:0031481:::HP:0001634:::HP:0001718:::HP:0034376:::HP... | 0.0049:::0.1483:::0.1707:::0.2393:::0.2420:::0.2552:::0.2809:::0.2921:::0.2968::... | mitral valve regurgitation [mitral regurgitation]:::abnormality of the mitral va... | Fyler:1151||SNOMEDCT_US:48724000||UMLS:C0026266||UMLS:C3551535:::UMLS:C4025759::... |
+| hypertension               | HP       | HP:0000822 | hypertension [hypertension]                             | HP:0000822:::HP:0100735:::HP:0032263:::HP:0100817:::HP:6000321:::HP:0000875:::HP... | 0.0088:::0.1680:::0.1913:::0.2054:::0.2201:::0.2393:::0.2534:::0.2540:::0.2642::... | hypertension [hypertension]:::hypertensive crisis [hypertensive crisis]:::increa... | SNOMEDCT_US:24184005||SNOMEDCT_US:38341003||UMLS:C0020538||UMLS:C0497247:::SNOME... |
+| dizzy spells               | HP       | HP:0002321 | dizzy spell [vertigo]                                   | HP:0002321:::HP:4000033:::HP:0010532:::HP:0001279:::HP:5200066:::HP:0025229:::HP... | 0.0348:::0.2809:::0.3412:::0.3516:::0.4048:::0.4180:::0.4322:::0.4366:::0.4444::... | dizzy spell [vertigo]:::non-spinning vertigo [non-spinning vertigo]:::paroxysmal... | SNOMEDCT_US:271789005||SNOMEDCT_US:399090003||SNOMEDCT_US:399153001||SNOMEDCT_US... |
+| bradycardia                | HP       | HP:0001662 | bradycardia [bradycardia]                               | HP:0001662:::HP:0001688:::HP:0033992:::HP:0011675:::HP:5200038:::HP:0031843:::HP... | 0.0551:::0.1935:::0.2446:::0.3437:::0.3797:::0.3834:::0.3878:::0.4167:::0.4231::... | bradycardia [bradycardia]:::sinus bradycardia [sinus bradycardia]:::chronotropic... | SNOMEDCT_US:48867003||UMLS:C0428977:::Fyler:7013||SNOMEDCT_US:49710005||UMLS:C00... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_HPO|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[mpnet_embeddings]|
+|Output Labels:|[hpo_code]|
+|Language:|en|
+|Size:|130.4 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-20-biolordresolve_HPO_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-20-biolordresolve_HPO_en.md
@@ -32,6 +32,7 @@ This model maps phenotypic abnormalities and medical terms associated with hered
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 documentAssembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-20-hpo_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-20-hpo_mapper_en.md
@@ -32,6 +32,7 @@ This model maps extracted phenotype entities from clinical or biomedical text to
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-20-hpo_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-20-hpo_mapper_en.md
@@ -1,0 +1,206 @@
+---
+layout: model
+title: Mapping Phenotype Entities with Corresponding HPO Codes
+author: John Snow Labs
+name: hpo_mapper
+date: 2026-07-20
+tags: [en, chunk_mapper, licensed, clinical, hpo]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted phenotype entities from clinical or biomedical text to their corresponding Human Phenotype Ontology (HPO) codes, standardizing observed symptoms, signs, and clinical abnormalities using HPO terminology. It also returns all possible matching codes for ambiguous surface forms in the `all_k_resolutions` metadata field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hpo_mapper_en_6.4.0_3.4_1784589687417.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hpo_mapper_en_6.4.0_3.4_1784589687417.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["document"])\
+    .setOutputCol("token")
+
+stopwords_cleaner = StopWordsCleaner()\
+    .setInputCols("token")\
+    .setOutputCol("cleanTokens")\
+    .setCaseSensitive(False)
+
+token_assembler = TokenAssembler()\
+    .setInputCols(["document", "cleanTokens"])\
+    .setOutputCol("cleanTokens_newDoc")
+
+sentence_detector = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["cleanTokens_newDoc"])\
+    .setOutputCol("sentence")
+
+tokenizer_2 = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("clean_tokens")
+
+hpo_matcher = TextMatcherInternalModel().pretrained("hpo_matcher", "en", "clinical/models")\
+    .setInputCols(["sentence", "clean_tokens"])\
+    .setOutputCol("hpo_term")\
+    .setCaseSensitive(False)\
+    .setMergeOverlapping(False)
+
+hpo_mapper = ChunkMapperModel().pretrained("hpo_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_term"])\
+    .setOutputCol("hpo_code")\
+    .setLowerCase(True)
+
+pipeline = Pipeline(stages=[
+    document_assembler, tokenizer, stopwords_cleaner, token_assembler,
+    sentence_detector, tokenizer_2, hpo_matcher, hpo_mapper
+])
+data = spark.createDataFrame([["The patient presents with memory impairment and seizures. Physical exam notable for microcephaly and low-set ears. Cardiac evaluation revealed a ventricular septal defect. The patient was diagnosed with ASD."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["document"])\
+    .setOutputCol("token")
+
+stopwords_cleaner = nlp.StopWordsCleaner()\
+    .setInputCols("token")\
+    .setOutputCol("cleanTokens")\
+    .setCaseSensitive(False)
+
+token_assembler = nlp.TokenAssembler()\
+    .setInputCols(["document", "cleanTokens"])\
+    .setOutputCol("cleanTokens_newDoc")
+
+sentence_detector = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["cleanTokens_newDoc"])\
+    .setOutputCol("sentence")
+
+tokenizer_2 = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("clean_tokens")
+
+hpo_matcher = medical.TextMatcherInternalModel().pretrained("hpo_matcher", "en", "clinical/models")\
+    .setInputCols(["sentence", "clean_tokens"])\
+    .setOutputCol("hpo_term")\
+    .setCaseSensitive(False)\
+    .setMergeOverlapping(False)
+
+hpo_mapper = medical.ChunkMapperModel().pretrained("hpo_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_term"])\
+    .setOutputCol("hpo_code")\
+    .setLowerCase(True)
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler, tokenizer, stopwords_cleaner, token_assembler,
+    sentence_detector, tokenizer_2, hpo_matcher, hpo_mapper
+])
+data = spark.createDataFrame([["The patient presents with memory impairment and seizures. Physical exam notable for microcephaly and low-set ears. Cardiac evaluation revealed a ventricular septal defect. The patient was diagnosed with ASD."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("document")
+    .setOutputCol("token")
+
+val stopwordsCleaner = new StopWordsCleaner()
+    .setInputCols("token")
+    .setOutputCol("cleanTokens")
+    .setCaseSensitive(false)
+
+val tokenAssembler = new TokenAssembler()
+    .setInputCols(Array("document", "cleanTokens"))
+    .setOutputCol("cleanTokens_newDoc")
+
+val sentenceDetector = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("cleanTokens_newDoc"))
+    .setOutputCol("sentence")
+
+val tokenizer2 = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("clean_tokens")
+
+val hpoMatcher = TextMatcherInternalModel
+    .pretrained("hpo_matcher", "en", "clinical/models")
+    .setInputCols(Array("sentence", "clean_tokens"))
+    .setOutputCol("hpo_term")
+    .setCaseSensitive(false)
+    .setMergeOverlapping(false)
+
+val hpoMapper = ChunkMapperModel
+    .pretrained("hpo_mapper", "en", "clinical/models")
+    .setInputCols("hpo_term")
+    .setOutputCol("hpo_code")
+    .setLowerCase(true)
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, tokenizer, stopwordsCleaner, tokenAssembler,
+    sentenceDetector, tokenizer2, hpoMatcher, hpoMapper
+))
+
+val data = Seq("The patient presents with memory impairment and seizures. Physical exam notable for microcephaly and low-set ears. Cardiac evaluation revealed a ventricular septal defect. The patient was diagnosed with ASD.").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| chunk                     | hpo_code   | all_k_resolutions       |
+|:--------------------------|:-----------|:------------------------|
+| memory impairment         | HP:0002354 | HP:0002354:::           |
+| seizures                  | HP:0001250 | HP:0001250:::           |
+| microcephaly              | HP:0000252 | HP:0000252:::           |
+| low-set ears              | HP:0000369 | HP:0000369:::           |
+| ventricular septal defect | HP:0001629 | HP:0001629:::           |
+| ASD                       | HP:0000729 | HP:0000729:::HP:0001631 |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hpo_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|980.6 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-20-sbiobertresolve_HPO_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-20-sbiobertresolve_HPO_en.md
@@ -1,0 +1,219 @@
+---
+layout: model
+title: Sentence Entity Resolver for HPO (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_HPO
+date: 2026-07-20
+tags: [en, entity_resolution, licensed, clinical, hpo, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps phenotypic abnormalities and medical terms associated with hereditary diseases to Human Phenotype Ontology (HPO) codes using `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings. It also returns associated codes from SNOMEDCT_US, UMLS, ORPHA, EPCC, and Fyler vocabularies in the `all_k_aux_labels` metadata field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_HPO_en_6.4.0_3.4_1784586607387.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_HPO_en_6.4.0_3.4_1784586607387.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["HP"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx","en","clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_HPO","en","clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("hpo")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+])
+
+data = spark.createDataFrame([["She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["HP"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx","en","clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_HPO","en","clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("hpo")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+])
+
+data = spark.createDataFrame([["She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("HP"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en","clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sentence_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_HPO", "en", "clinical/models")
+    .setInputCols(Array("sentence_embeddings"))
+    .setOutputCol("hpo")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("She is followed by Dr. X in our office and has a history of severe tricuspid regurgitation. On 05/12/08, preserved left and right ventricular systolic function, aortic sclerosis with apparent mild aortic stenosis. She has previously had a Persantine Myoview nuclear rest-stress test scan completed at ABCD Medical Center in 07/06 that was negative. She has had significant mitral valve regurgitation in the past being moderate, but on the most recent echocardiogram on 05/12/08, that was not felt to be significant. She does have a history of significant hypertension in the past. She has had dizzy spells and denies clearly any true syncope. She has had bradycardia in the past from beta-blocker therapy.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                  | entity   | hpo_code   | resolution                                        | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:---------------------------|:---------|:-----------|:--------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| tricuspid regurgitation    | HP       | HP:0005180 | tricuspid regurgitation [tricuspid regurgitation] | HP:0005180:::HP:0010446:::HP:0001704:::HP:0001702:::HP:0030732:::HP:0031444:::HP... | 0.0000:::0.0538:::0.0609:::0.0757:::0.0794:::0.0873:::0.0879:::0.0899:::0.0893::... | tricuspid regurgitation [tricuspid regurgitation]:::tricuspid stenosis [tricuspi... | Fyler:1161||SNOMEDCT_US:111287006||UMLS:C0040961:::EPCC:06.01.92||ICD-10:Q22.4||... |
+| aortic stenosis            | HP       | HP:0001650 | aortic stenosis [aortic valve stenosis]           | HP:0001650:::HP:0001682:::HP:0004381:::HP:0005174:::HP:0001691:::HP:0005145:::HP... | 0.0000:::0.0296:::0.0412:::0.0618:::0.0677:::0.0751:::0.0762:::0.0770:::0.0816::... | aortic stenosis [aortic valve stenosis]:::subvalvular aortic stenosis [subvalvul... | Fyler:1411||SNOMEDCT_US:60573004||UMLS:C0003507:::SNOMEDCT_US:204368006||UMLS:C0... |
+| mitral valve regurgitation | HP       | HP:0001653 | mitral valve regurgitation [mitral regurgitation] | HP:0001653:::HP:0001718:::HP:0001633:::HP:0001634:::HP:0031478:::HP:0031481:::HP... | 0.0000:::0.0495:::0.0573:::0.0682:::0.0687:::0.0700:::0.0706:::0.0706:::0.0757::... | mitral valve regurgitation [mitral regurgitation]:::mitral valve stenosis [mitra... | Fyler:1151||SNOMEDCT_US:48724000||UMLS:C0026266||UMLS:C3551535:::EPCC:06.02.92||... |
+| hypertension               | HP       | HP:0000822 | hypertension [hypertension]                       | HP:0000822:::HP:6000321:::HP:0007906:::HP:0000875:::HP:0430034:::HP:0100735:::HP... | 0.0000:::0.0604:::0.0735:::0.0937:::0.0959:::0.1081:::0.1109:::0.1130:::0.1167::... | hypertension [hypertension]:::labile hypertension [labile hypertension]:::ocular... | SNOMEDCT_US:24184005||SNOMEDCT_US:38341003||UMLS:C0020538||UMLS:C0497247::::::SN... |
+| dizzy spells               | HP       | HP:0002321 | dizzy spell [vertigo]                             | HP:0002321:::HP:0006961:::HP:0012668:::HP:6000456:::HP:0001279:::HP:0000975:::HP... | 0.0183:::0.1165:::0.1221:::0.1306:::0.1324:::0.1299:::0.1335:::0.1428:::0.1434::... | dizzy spell [vertigo]:::jerky head movements [jerky head movements]:::situationa... | SNOMEDCT_US:271789005||SNOMEDCT_US:399090003||SNOMEDCT_US:399153001||SNOMEDCT_US... |
+| bradycardia                | HP       | HP:0001662 | bradycardia [bradycardia]                         | HP:0001662:::HP:0001688:::HP:0002067:::HP:0046507:::HP:0000966:::HP:0031843:::HP... | 0.0000:::0.0207:::0.0716:::0.0792:::0.1065:::0.1136:::0.1125:::0.1162:::0.1174::... | bradycardia [bradycardia]:::sinus bradycardia [sinus bradycardia]:::bradykinesia... | SNOMEDCT_US:48867003||UMLS:C0428977:::Fyler:7013||SNOMEDCT_US:49710005||UMLS:C00... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_HPO|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sentence_embeddings]|
+|Output Labels:|[hpo_code]|
+|Language:|en|
+|Size:|130.0 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-20-sbiobertresolve_HPO_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-20-sbiobertresolve_HPO_en.md
@@ -32,6 +32,7 @@ This model maps phenotypic abnormalities and medical terms associated with hered
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 documentAssembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-gene_hpo_code_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-gene_hpo_code_mapper_en.md
@@ -32,6 +32,7 @@ This model maps gene symbols to their associated HPO code(s), based on gene-phen
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-gene_hpo_code_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-gene_hpo_code_mapper_en.md
@@ -1,0 +1,122 @@
+---
+layout: model
+title: Mapping Genes with Their Corresponding HPO Codes
+author: John Snow Labs
+name: gene_hpo_code_mapper
+date: 2026-07-21
+tags: [en, chunk_mapper, licensed, clinical, hpo, gene]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene symbols to their associated HPO code(s), based on gene-phenotype associations curated by the Human Phenotype Ontology (HPO) project (reverse direction of `hpo_code_gene_mapper`). Genes linked to more than one HPO code return every associated code via the `all_k_resolutions` metadata field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/gene_hpo_code_mapper_en_6.4.0_3.4_1784640820746.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/gene_hpo_code_mapper_en_6.4.0_3.4_1784640820746.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+gene_hpo_code_mapper = ChunkMapperModel.pretrained("gene_hpo_code_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hpo_code"])
+
+pipeline = Pipeline(stages=[document_assembler, chunk_assembler, gene_hpo_code_mapper])
+data = spark.createDataFrame([["CHN1"], ["MDH1"], ["SNAP25"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+gene_hpo_code_mapper = medical.ChunkMapperModel.pretrained("gene_hpo_code_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hpo_code"])
+
+pipeline = nlp.Pipeline(stages=[document_assembler, chunk_assembler, gene_hpo_code_mapper])
+data = spark.createDataFrame([["CHN1"], ["MDH1"], ["SNAP25"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val chunkAssembler = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("ner_chunk")
+
+val geneHpoCodeMapper = ChunkMapperModel
+    .pretrained("gene_hpo_code_mapper", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("hpo_code"))
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, chunkAssembler, geneHpoCodeMapper))
+val data = Seq("CHN1", "MDH1", "SNAP25").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| gene   | hpo_code   | all_k_resolutions                                                                                       |
+|:-------|:-----------|:--------------------------------------------------------------------------------------------------------|
+| CHN1   | HP:0001177 | HP:0001177:::HP:0001156:::HP:0025186:::HP:0001199:::HP:0009921:::HP:0001250:::HP:0001263:::HP:000740... |
+| MDH1   | HP:0500149 | HP:0500149:::HP:0001276:::HP:0001250:::HP:0001263:::HP:0100876:::HP:0002521:::HP:0001338:::HP:000000... |
+| SNAP25 | HP:0002465 | HP:0002465:::HP:0002421:::HP:0003701:::HP:0001270:::HP:0001288:::HP:0001283:::HP:0001284:::HP:000125... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|gene_hpo_code_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|771.7 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_eom_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_eom_mapper_en.md
@@ -31,6 +31,7 @@ This model maps HPO codes to their associated Elements of Morphology (EOM) id(s)
 
 
 <div class="tabs-box" markdown="1">
+  
 {% include programmingLanguageSelectScalaPythonNLU.html %}
 ```python
 

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_eom_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_eom_mapper_en.md
@@ -1,0 +1,122 @@
+---
+layout: model
+title: Mapping HPO Codes with Their Corresponding EOM Ids
+author: John Snow Labs
+name: hpo_code_eom_mapper
+date: 2026-07-21
+tags: [en, chunk_mapper, licensed, clinical, hpo, eom]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps HPO codes to their associated Elements of Morphology (EOM) id(s), based on the HPO project's own EOM crosswalk. Codes linked to more than one EOM id return every associated id via the `all_k_resolutions` metadata field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hpo_code_eom_mapper_en_6.4.0_3.4_1784646871487.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hpo_code_eom_mapper_en_6.4.0_3.4_1784646871487.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("hpo_code")
+
+hpo_code_eom_mapper = ChunkMapperModel.pretrained("hpo_code_eom_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_code"])\
+    .setOutputCol("mappings")\
+    .setRels(["eom"])
+
+pipeline = Pipeline(stages=[document_assembler, chunk_assembler, hpo_code_eom_mapper])
+data = spark.createDataFrame([["HP:0000154"], ["HP:0400001"], ["HP:0009765"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("hpo_code")
+
+hpo_code_eom_mapper = medical.ChunkMapperModel.pretrained("hpo_code_eom_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_code"])\
+    .setOutputCol("mappings")\
+    .setRels(["eom"])
+
+pipeline = nlp.Pipeline(stages=[document_assembler, chunk_assembler, hpo_code_eom_mapper])
+data = spark.createDataFrame([["HP:0000154"], ["HP:0400001"], ["HP:0009765"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val chunkAssembler = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("hpo_code")
+
+val hpoCodeEomMapper = ChunkMapperModel
+    .pretrained("hpo_code_eom_mapper", "en", "clinical/models")
+    .setInputCols(Array("hpo_code"))
+    .setOutputCol("mappings")
+    .setRels(Array("eom"))
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, chunkAssembler, hpoCodeEomMapper))
+val data = Seq("HP:0000154", "HP:0400001", "HP:0009765").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| hpo_code   | eom                  | all_k_resolutions       |
+|:-----------|:---------------------|:------------------------|
+| HP:0000154 | EOM:a6a2d57a281ead72 | EOM:a6a2d57a281ead72::: |
+| HP:0400001 | EOM:8a5493c72e0dd13c | EOM:8a5493c72e0dd13c::: |
+| HP:0009765 | EOM:49acd433e354541b | EOM:49acd433e354541b::: |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hpo_code_eom_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|10.3 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_gene_disease_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_gene_disease_mapper_en.md
@@ -32,6 +32,7 @@ This model maps HPO codes to their associated gene(s), and for each gene returns
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_gene_disease_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_gene_disease_mapper_en.md
@@ -1,0 +1,122 @@
+---
+layout: model
+title: Mapping HPO Codes with Their Corresponding Genes and Related Phenotypes
+author: John Snow Labs
+name: hpo_code_gene_disease_mapper
+date: 2026-07-21
+tags: [en, chunk_mapper, licensed, clinical, hpo, gene, disease]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps HPO codes to their associated gene(s), and for each gene returns the phenotype terms associated with that gene elsewhere in the Human Phenotype Ontology (HPO). Codes linked to more than one gene return every associated gene's phenotype list via the `all_k_resolutions` metadata field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hpo_code_gene_disease_mapper_en_6.4.0_3.4_1784663524659.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hpo_code_gene_disease_mapper_en_6.4.0_3.4_1784663524659.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("hpo_code")
+
+hpo_code_gene_disease_mapper = ChunkMapperModel.pretrained("hpo_code_gene_disease_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_code"])\
+    .setOutputCol("mappings")\
+    .setRels(["hpo_gene_disease"])
+
+pipeline = Pipeline(stages=[document_assembler, chunk_assembler, hpo_code_gene_disease_mapper])
+data = spark.createDataFrame([["HP:0000002"], ["HP:6001080"], ["HP:0009484"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("hpo_code")
+
+hpo_code_gene_disease_mapper = medical.ChunkMapperModel.pretrained("hpo_code_gene_disease_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_code"])\
+    .setOutputCol("mappings")\
+    .setRels(["hpo_gene_disease"])
+
+pipeline = nlp.Pipeline(stages=[document_assembler, chunk_assembler, hpo_code_gene_disease_mapper])
+data = spark.createDataFrame([["HP:0000002"], ["HP:6001080"], ["HP:0009484"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val chunkAssembler = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("hpo_code")
+
+val hpoCodeGeneDiseaseMapper = ChunkMapperModel
+    .pretrained("hpo_code_gene_disease_mapper", "en", "clinical/models")
+    .setInputCols(Array("hpo_code"))
+    .setOutputCol("mappings")
+    .setRels(Array("hpo_gene_disease"))
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, chunkAssembler, hpoCodeGeneDiseaseMapper))
+val data = Seq("HP:0000002", "HP:6001080", "HP:0009484").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| hpo_code   |   n_genes | gene_disease                                                                                                                                              | all_k_resolutions                                                                                                                                         |
+|:-----------|----------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| HP:0000002 |        25 | {"TBCB": ["polyneuropathy", "motor delay", "hypotonia", "intellectual disability", "spasticity", "slender finger", "interictal eeg abnormality", "abno... | {"TBCB": ["polyneuropathy", "motor delay", "hypotonia", "intellectual disability", "spasticity", "slender finger", "interictal eeg abnormality", "abno... |
+| HP:6001080 |         1 | {"HSD11B1": ["abnormal circulating deoxycorticosterone level", "autosomal dominant inheritance", "elevated serum 11-deoxycortisol", "decreased circula... | {"HSD11B1": ["abnormal circulating deoxycorticosterone level", "autosomal dominant inheritance", "elevated serum 11-deoxycortisol", "decreased circula... |
+| HP:0009484 |         2 | {"SHH": ["abnormal thumb morphology", "hand polydactyly", "poor speech", "expressive language delay", "limb dystonia", "oromotor apraxia", "single nar... | {"SHH": ["abnormal thumb morphology", "hand polydactyly", "poor speech", "expressive language delay", "limb dystonia", "oromotor apraxia", "single nar... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hpo_code_gene_disease_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|122.3 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_gene_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_gene_mapper_en.md
@@ -32,6 +32,7 @@ This model maps HPO codes to their associated gene symbol(s), based on gene-phen
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_gene_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_code_gene_mapper_en.md
@@ -1,0 +1,122 @@
+---
+layout: model
+title: Mapping HPO Codes with Their Corresponding Genes
+author: John Snow Labs
+name: hpo_code_gene_mapper
+date: 2026-07-21
+tags: [en, chunk_mapper, licensed, clinical, hpo, gene]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps HPO codes to their associated gene symbol(s), based on gene-phenotype associations curated by the Human Phenotype Ontology (HPO) project. Codes linked to more than one gene return every associated gene via the `all_k_resolutions` metadata field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hpo_code_gene_mapper_en_6.4.0_3.4_1784638395565.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hpo_code_gene_mapper_en_6.4.0_3.4_1784638395565.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("hpo_code")
+
+hpo_code_gene_mapper = ChunkMapperModel.pretrained("hpo_code_gene_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_code"])\
+    .setOutputCol("mappings")\
+    .setRels(["gene"])
+
+pipeline = Pipeline(stages=[document_assembler, chunk_assembler, hpo_code_gene_mapper])
+data = spark.createDataFrame([["HP:0000002"], ["HP:6001080"], ["HP:0009484"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("hpo_code")
+
+hpo_code_gene_mapper = medical.ChunkMapperModel.pretrained("hpo_code_gene_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_code"])\
+    .setOutputCol("mappings")\
+    .setRels(["gene"])
+
+pipeline = nlp.Pipeline(stages=[document_assembler, chunk_assembler, hpo_code_gene_mapper])
+data = spark.createDataFrame([["HP:0000002"], ["HP:6001080"], ["HP:0009484"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val chunkAssembler = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("hpo_code")
+
+val hpoCodeGeneMapper = ChunkMapperModel
+    .pretrained("hpo_code_gene_mapper", "en", "clinical/models")
+    .setInputCols(Array("hpo_code"))
+    .setOutputCol("mappings")
+    .setRels(Array("gene"))
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, chunkAssembler, hpoCodeGeneMapper))
+val data = Seq("HP:0000002", "HP:6001080", "HP:0009484").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| hpo_code   | gene    | all_k_resolutions                                                                                       |
+|:-----------|:--------|:--------------------------------------------------------------------------------------------------------|
+| HP:0000002 | TBCB    | TBCB:::DUSP6:::FGF8:::FGFR1:::GNRH1:::GNRHR:::HIVEP2:::KISS1:::LRP5:::NHLH2:::PDGFRB:::TAC3:::TACR3:... |
+| HP:6001080 | HSD11B1 | HSD11B1:::                                                                                              |
+| HP:0009484 | SHH     | SHH:::LMBR1                                                                                             |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hpo_code_gene_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|973.5 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_disease_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_disease_mapper_en.md
@@ -32,6 +32,7 @@ This model maps HPO codes to the real disease(s) they are associated with, based
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_disease_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_disease_mapper_en.md
@@ -1,0 +1,122 @@
+---
+layout: model
+title: Mapping HPO Codes with Their Corresponding Diseases
+author: John Snow Labs
+name: hpo_disease_mapper
+date: 2026-07-21
+tags: [en, chunk_mapper, licensed, clinical, hpo, disease]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps HPO codes to the real disease(s) they are associated with, based on the Human Phenotype Ontology's own phenotype-disease annotations (OMIM, Orphanet, and DECIPHER identifiers). Two positionally-aligned relations are available: `disease_id` and `disease_name`. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hpo_disease_mapper_en_6.4.0_3.4_1784666560448.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hpo_disease_mapper_en_6.4.0_3.4_1784666560448.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("hpo_code")
+
+hpo_disease_mapper = ChunkMapperModel.pretrained("hpo_disease_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_code"])\
+    .setOutputCol("mappings")\
+    .setRels(["disease_id"])  # or disease_name
+
+pipeline = Pipeline(stages=[document_assembler, chunk_assembler, hpo_disease_mapper])
+data = spark.createDataFrame([["HP:0000025"], ["HP:0000058"], ["HP:0000002"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("hpo_code")
+
+hpo_disease_mapper = medical.ChunkMapperModel.pretrained("hpo_disease_mapper", "en", "clinical/models")\
+    .setInputCols(["hpo_code"])\
+    .setOutputCol("mappings")\
+    .setRels(["disease_id"])  # or disease_name
+
+pipeline = nlp.Pipeline(stages=[document_assembler, chunk_assembler, hpo_disease_mapper])
+data = spark.createDataFrame([["HP:0000025"], ["HP:0000058"], ["HP:0000002"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val chunkAssembler = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("hpo_code")
+
+val hpoDiseaseMapper = ChunkMapperModel
+    .pretrained("hpo_disease_mapper", "en", "clinical/models")
+    .setInputCols(Array("hpo_code"))
+    .setOutputCol("mappings")
+    .setRels(Array("disease_id"))  // or disease_name
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, chunkAssembler, hpoDiseaseMapper))
+val data = Seq("HP:0000025", "HP:0000058", "HP:0000002").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| hpo_code   |   n_diseases | disease_id   | all_k_resolutions                                                                                                                         |
+|:-----------|-------------:|:-------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| HP:0000025 |            1 | ORPHA:904    | ORPHA:904:::                                                                                                                              |
+| HP:0000058 |            3 | ORPHA:251510 | ORPHA:251510:::ORPHA:37202:::ORPHA:325345                                                                                                 |
+| HP:0000002 |           10 | OMIM:144750  | OMIM:144750:::OMIM:186570:::OMIM:617800:::OMIM:621382:::OMIM:621091:::OMIM:612475:::OMIM:616977:::ORPHA:209964:::ORPHA:140976:::ORPHA:432 |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hpo_disease_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|4.6 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_parent_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_parent_mapper_en.md
@@ -32,6 +32,7 @@ This model maps HPO codes to their full ancestor hierarchy in the Human Phenotyp
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_parent_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_parent_mapper_en.md
@@ -1,0 +1,122 @@
+---
+layout: model
+title: Mapping HPO Codes with Their Corresponding Parent Terms
+author: John Snow Labs
+name: hpo_parent_mapper
+date: 2026-07-21
+tags: [en, chunk_mapper, licensed, clinical, hpo, parent]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps HPO codes to their full ancestor hierarchy in the Human Phenotype Ontology (HPO) — every parent term from the given code up to the ontology root, not just the direct parent. For each ancestor it returns the HPO code, label, and official ontology description, joined into one or more ancestor paths (multiple paths are returned for codes with more than one parent branch). Also returns the code's own canonical label via the `resolution` relation. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hpo_parent_mapper_en_6.4.0_3.4_1784595486814.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hpo_parent_mapper_en_6.4.0_3.4_1784595486814.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+hpo_parent_mapper = ChunkMapperModel.pretrained("hpo_parent_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["resolution", "parents"])  # or just ["parents"]
+
+pipeline = Pipeline(stages=[document_assembler, chunk_assembler, hpo_parent_mapper])
+data = spark.createDataFrame([["HP:0002354"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+hpo_parent_mapper = medical.ChunkMapperModel.pretrained("hpo_parent_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["resolution", "parents"])  # or just ["parents"]
+
+pipeline = nlp.Pipeline(stages=[document_assembler, chunk_assembler, hpo_parent_mapper])
+data = spark.createDataFrame([["HP:0002354"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val chunkAssembler = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("ner_chunk")
+
+val hpoParentMapper = ChunkMapperModel
+    .pretrained("hpo_parent_mapper", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("resolution", "parents"))  // or just Array("parents")
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, chunkAssembler, hpoParentMapper))
+val data = Seq("HP:0002354").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| code       | resolution                |   n_ancestor_paths | sample_ancestor_path                                                                                                                                                                                                                                                                                            |
+|:-----------|:--------------------------|-------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| HP:0002354 | Memory impairment         |                  1 | HP:0100543: Cognitive impairment ## An individual with cognitive impairment may experience difficulties in remembering, learning new things, concentrating, or making decisions. => HP:0011446: Abnormality of mental function ## This includes abnormalities in speech, mood, emotions, behavior, and cogni... |
+| HP:0001629 | Ventricular septal defect |                  2 | HP:0010438: Abnormal ventricular septum morphology ## A structural abnormality of the interventricular septum. => HP:0001671: Abnormal cardiac septum morphology ## An anomaly of the intra-atrial or intraventricular septum. => HP:0001627: Abnormal heart morphology ## Any structural anomaly of the hea... |
+| HP:0000252 | Microcephaly              |                  4 | HP:0007364: Aplasia/Hypoplasia of the cerebrum ## Absent/small cerebrum => HP:0002060: Abnormal cerebral morphology ## Any structural abnormality of the telencephalon, which is also known as the cerebrum. => HP:0100547: Abnormal forebrain morphology ## An abnormality of the forebrain, which has as i... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hpo_parent_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|9.7 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_synonym_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_synonym_mapper_en.md
@@ -1,0 +1,145 @@
+---
+layout: model
+title: Mapping Phenotype Terms with Their Corresponding Synonyms
+author: John Snow Labs
+name: hpo_synonym_mapper
+date: 2026-07-21
+tags: [en, chunk_mapper, licensed, clinical, hpo, synonym]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps HPO phenotype terms found in free text to their exact, related, broad, and narrow synonyms, enabling standardized recognition and linking of phenotypic concepts across clinical and biomedical text via the `synonym` field. Trained on the Human Phenotype Ontology (HPO) 2026-06-23 release.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hpo_synonym_mapper_en_6.4.0_3.4_1784660133556.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hpo_synonym_mapper_en_6.4.0_3.4_1784660133556.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["document"])\
+    .setOutputCol("token")
+
+entity_extractor = TextMatcherInternalModel().pretrained("hpo_matcher", "en", "clinical/models")\
+    .setInputCols(["document", "token"])\
+    .setOutputCol("ner_chunk")\
+    .setCaseSensitive(False)\
+    .setMergeOverlapping(False)
+
+hpo_synonym_mapper = ChunkMapperModel.pretrained("hpo_synonym_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["synonym"])
+
+pipeline = Pipeline(stages=[document_assembler, tokenizer, entity_extractor, hpo_synonym_mapper])
+data = spark.createDataFrame([["""The patient presents with memory impairment and seizures. Physical exam notable for microcephaly, hypotonia, micrognathia, and low-set ears. Head shape assessment revealed plagiocephaly. Cardiac evaluation revealed a ventricular septal defect."""]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["document"])\
+    .setOutputCol("token")
+
+entity_extractor = medical.TextMatcherModel().pretrained("hpo_matcher", "en", "clinical/models")\
+    .setInputCols(["document", "token"])\
+    .setOutputCol("ner_chunk")\
+    .setCaseSensitive(False)\
+    .setMergeOverlapping(False)
+
+hpo_synonym_mapper = medical.ChunkMapperModel.pretrained("hpo_synonym_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["synonym"])
+
+pipeline = nlp.Pipeline(stages=[document_assembler, tokenizer, entity_extractor, hpo_synonym_mapper])
+data = spark.createDataFrame([["""The patient presents with memory impairment and seizures. Physical exam notable for microcephaly, hypotonia, micrognathia, and low-set ears. Head shape assessment revealed plagiocephaly. Cardiac evaluation revealed a ventricular septal defect."""]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("document")
+    .setOutputCol("token")
+
+val entityExtractor = TextMatcherInternalModel().pretrained("hpo_matcher", "en", "clinical/models")
+    .setInputCols(Array("document", "token"))
+    .setOutputCol("ner_chunk")
+    .setCaseSensitive(false)
+    .setMergeOverlapping(false)
+
+val hpoSynonymMapper = ChunkMapperModel
+    .pretrained("hpo_synonym_mapper", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("synonym"))
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, tokenizer, entityExtractor, hpoSynonymMapper))
+val data = Seq("""The patient presents with memory impairment and seizures. Physical exam notable for microcephaly, hypotonia, micrognathia, and low-set ears. Head shape assessment revealed plagiocephaly. Cardiac evaluation revealed a ventricular septal defect.""").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| term                      | synonym                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|:--------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| seizures                  | {'exact_synonym': ['epileptic seizure', 'seizure'], 'related_synonym': ['epilepsy'], 'broad_synonym': [], 'narrow_synonym': []}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| micrognathia              | {'exact_synonym': ['decreased size of lower jaw', 'decreased size of mandible', 'hypoplasia of lower jaw', 'hypoplasia of mandible', 'hypoplastic mandible', 'hypoplastic mandible condyle', 'hypotrophic lower jaw', 'hypotrophic mandible', 'little lower jaw', 'little mandible', 'lower jaw deficiency', 'lower jaw hypoplasia', 'mandibular deficiency', 'mandibular hypoplasia', 'mandibular micrognathia', 'micrognathia of lower jaw', 'micromandible', 'robin mandible', 'severe hypoplasia of mandible', 'small jaw', 'small lower jaw', 'small mandible', 'underdevelopment of lower jaw', 'underdevelopment ... |
+| plagiocephaly             | {'exact_synonym': ['flat head syndrome', 'flattening of cranial vault', 'flattening of cranium', 'flattening of skull', 'rhomboid shaped cranium', 'rhomboid shaped skull'], 'related_synonym': [], 'broad_synonym': ['asymmetry of the posterior cranium', 'asymmetry of the posterior head', 'asymmetry of the posterior skull', 'flat head', 'rhomboid shaped head'], 'narrow_synonym': ['deformational plagiocephaly', 'flattening of head', 'positional plagiocephaly']}                                                                                                                                               |
+| microcephaly              | {'exact_synonym': ['abnormally small cranium', 'abnormally small skull', 'decreased circumference of cranium', 'decreased size of cranium', 'decreased size of skull', 'reduced head circumference', 'small cranium', 'small head circumference'], 'related_synonym': [], 'broad_synonym': ['abnormally small head', 'decreased size of head', 'small head', 'small skull'], 'narrow_synonym': ['small calvarium']}                                                                                                                                                                                                         |
+| ventricular septal defect | {'exact_synonym': ['hole in heart wall separating two lower heart chambers', 'ventricular septal defects', 'ventriculoseptal defect', 'vsd'], 'related_synonym': [], 'broad_synonym': [], 'narrow_synonym': []}                                                                                                                                                                                                                                                                                                                                                                                                             |
+| memory impairment         | {'exact_synonym': ['amnesia', 'forgetfulness', 'memory impairment', 'memory loss', 'memory problems', 'poor memory'], 'related_synonym': [], 'broad_synonym': [], 'narrow_synonym': []}                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| hypotonia                 | {'exact_synonym': ['low muscle tone', 'low or weak muscle tone', 'muscle hypotonia', 'muscular hypotonia'], 'related_synonym': [], 'broad_synonym': [], 'narrow_synonym': ['central hypotonia', 'peripheral hypotonia']}                                                                                                                                                                                                                                                                                                                                                                                                    |
+| low-set ears              | {'exact_synonym': ['low set ears', 'low-set ears', 'low-set pinnae', 'lowset ears', 'melotia'], 'related_synonym': [], 'broad_synonym': [], 'narrow_synonym': []}                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hpo_synonym_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|2.0 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_synonym_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-21-hpo_synonym_mapper_en.md
@@ -32,6 +32,7 @@ This model maps HPO phenotype terms found in free text to their exact, related, 
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\


### PR DESCRIPTION
## HPO 20260623 — Resolvers & Mappers

Adds 3 sentence entity resolvers and 8 chunk mappers for the Human Phenotype Ontology (HPO), release 2026-06-23, to JSL Models Hub.

### Resolvers

| Model | Embedding | Status |
|---|---|---|
| `sbiobertresolve_HPO` | `sbiobert_base_cased_mli_onnx` | Updated |
| `biolordresolve_HPO` | `mpnet_embeddings_biolord_2023_c` | New |
| `bgeresolve_HPO` | `bge_base_en_v1_5_onnx` | New |

### Mappers

| Model | Direction | Status |
|---|---|---|
| `hpo_mapper` | phenotype text → HPO code | Updated |
| `hpo_parent_mapper` | HPO code → full ancestor chain | Updated |
| `hpo_code_gene_mapper` | HPO code → gene(s) | Updated |
| `gene_hpo_code_mapper` | gene → HPO code(s) | Updated |
| `hpo_code_eom_mapper` | HPO code → Elements of Morphology id(s) | Updated |
| `hpo_synonym_mapper` | phenotype text → synonym breakdown (exact/related/broad/narrow) | Updated |
| `hpo_code_gene_disease_mapper` | HPO code → gene → associated phenotype names | Updated |
| `hpo_disease_mapper` | HPO code → disease id(s) + name(s) (OMIM/Orphanet/DECIPHER) | New |
