### PR TITLE
2026-07-26-sbiobertresolve_ndc_en

### DIFF
--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-bgeresolve_ndc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-bgeresolve_ndc_en.md
@@ -32,6 +32,7 @@ This model maps clinical entities and concepts, particularly drugs and ingredien
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 documentAssembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-bgeresolve_ndc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-bgeresolve_ndc_en.md
@@ -1,0 +1,219 @@
+---
+layout: model
+title: Sentence Entity Resolver for NDC (bge_base_en_v1_5_onnx embeddings)
+author: John Snow Labs
+name: bgeresolve_ndc
+date: 2026-07-26
+tags: [en, entity_resolution, licensed, clinical, ndc, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical entities and concepts, particularly drugs and ingredients, to National Drug Codes. It leverages `bge_base_en_v1_5_onnx` Sentence Embeddings and provides package options plus alternative drug suggestions through the `all_k_aux_label` column. Trained on the openFDA NDC Directory (release 2026-07-22).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_ndc_en_6.4.0_3.4_1785070165721.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_ndc_en_6.4.0_3.4_1785070165721.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner = MedicalNerModel.pretrained("ner_posology_greedy","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx","en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+ndc_resolver = SentenceEntityResolverModel.pretrained("bgeresolve_ndc","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("ndc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, embedder, ndc_resolver
+])
+
+data = spark.createDataFrame([["She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner = medical.NerModel.pretrained("ner_posology_greedy","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx","en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+ndc_resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_ndc","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("ndc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, embedder, ndc_resolver
+])
+
+data = spark.createDataFrame([["She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner = MedicalNerModel
+    .pretrained("ner_posology_greedy", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("DRUG"))
+
+val c2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val ndc_resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_ndc", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("ndc_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, embedder, ndc_resolver
+))
+
+val data = Seq("She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                  | entity   | ndc_code   | resolution                   | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:---------------------------|:---------|:-----------|:-----------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| losartan potassium 50 mg   | DRUG     | 64380-0934 | losartan potassium 50 mg     | 64380-0934:::0904-7048:::59746-0334:::68180-0377:::70010-0742:::63187-0071:::643... | 0.0000:::0.1727:::0.2886:::0.3155:::0.3753:::0.3831:::0.4059:::0.4149:::0.4194::... | 0.0000:::0.0149:::0.0417:::0.0498:::0.0704:::0.0734:::0.0824:::0.0861:::0.0879::... | losartan potassium 50 mg:::losartan potassium 50 mg/1:::losartan potassium table... | {'packages': "['30 TABLET, FILM COATED in 1 BOTTLE (64380-934-04)', '90 TABLET, ... |
+| hydrochlorothiazide 25 mg  | DRUG     | 68645-0510 | hydrochlorothiazide 25 mg/1  | 68645-0510:::65649-0311:::0172-2089:::0591-0347:::70954-0522:::63323-0658:::6586... | 0.2113:::0.3800:::0.4210:::0.4341:::0.4525:::0.4719:::0.4898:::0.4910:::0.4955::... | 0.0223:::0.0722:::0.0886:::0.0942:::0.1024:::0.1113:::0.1200:::0.1206:::0.1227::... | hydrochlorothiazide 25 mg/1:::chlorothiazide 250 mg/5ml:::hydrochlorothiazide 50... | {'packages': "['30 TABLET in 1 BOTTLE (68645-510-54)']", 'alternatives': ['0172-... |
+| sertraline 50 mg           | DRUG     | 76282-0213 | sertraline 50 mg/1           | 76282-0213:::72189-0551:::0904-6925:::68645-0522:::58151-0575:::69238-2789:::762... | 0.2415:::0.3459:::0.3668:::0.4548:::0.4556:::0.4709:::0.4807:::0.4921:::0.5014::... | 0.0292:::0.0598:::0.0673:::0.1034:::0.1038:::0.1109:::0.1155:::0.1211:::0.1257::... | sertraline 50 mg/1:::sertraline hcl 50 mg/1:::sertraline hydrochloride 50 mg/1::... | {'packages': "['100 TABLET, FILM COATED in 1 BOTTLE (76282-213-01)', '500 TABLET... |
+| metoprolol succinate 25 mg | DRUG     | 55111-0466 | metoprolol succinate 25 mg/1 | 55111-0466:::61919-0754:::55111-0469:::55154-6886:::0904-6324:::63629-8863:::633... | 0.1410:::0.3366:::0.3419:::0.3584:::0.3587:::0.3777:::0.3791:::0.3809:::0.3831::... | 0.0099:::0.0566:::0.0584:::0.0642:::0.0643:::0.0713:::0.0718:::0.0725:::0.0734::... | metoprolol succinate 25 mg/1:::metoprolol succinate er 25 mg/1:::metoprolol succ... | {'packages': "['100 TABLET, FILM COATED, EXTENDED RELEASE in 1 BOTTLE (55111-466... |
+| gabapentin 300 mg          | DRUG     | 65862-0199 | gabapentin 300 mg/1          | 65862-0199:::70771-1861:::16714-0662:::53451-0103:::80425-0082:::81033-0124:::00... | 0.2162:::0.3360:::0.3471:::0.4207:::0.4656:::0.4932:::0.4976:::0.5001:::0.5056::... | 0.0234:::0.0564:::0.0603:::0.0885:::0.1084:::0.1216:::0.1238:::0.1251:::0.1278::... | gabapentin 300 mg/1:::gabapentin 300 mg/1 tablet:::gabapentin 300 mg/1 capsule::... | {'packages': "['2000 CAPSULE in 1 BAG (65862-199-26)', '100 CAPSULE in 1 BOTTLE ... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_ndc|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[ndc_code]|
+|Language:|en|
+|Size:|767.5 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-biolordresolve_ndc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-biolordresolve_ndc_en.md
@@ -32,6 +32,7 @@ This model maps clinical entities and concepts, particularly drugs and ingredien
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 documentAssembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-biolordresolve_ndc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-biolordresolve_ndc_en.md
@@ -1,0 +1,219 @@
+---
+layout: model
+title: Sentence Entity Resolver for NDC (mpnet_embeddings_biolord_2023_c embeddings)
+author: John Snow Labs
+name: biolordresolve_ndc
+date: 2026-07-26
+tags: [en, entity_resolution, licensed, clinical, ndc, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical entities and concepts, particularly drugs and ingredients, to National Drug Codes. It leverages `mpnet_embeddings_biolord_2023_c` Sentence Embeddings and provides package options plus alternative drug suggestions through the `all_k_aux_label` column. Trained on the openFDA NDC Directory (release 2026-07-22).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_ndc_en_6.4.0_3.4_1785069570547.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_ndc_en_6.4.0_3.4_1785069570547.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner = MedicalNerModel.pretrained("ner_posology_greedy","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c","en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("mpnet_embeddings")\
+    .setCaseSensitive(False)
+
+ndc_resolver = SentenceEntityResolverModel.pretrained("biolordresolve_ndc","en","clinical/models")\
+    .setInputCols(["mpnet_embeddings"])\
+    .setOutputCol("ndc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, embedder, ndc_resolver
+])
+
+data = spark.createDataFrame([["She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner = medical.NerModel.pretrained("ner_posology_greedy","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c","en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("mpnet_embeddings")\
+    .setCaseSensitive(False)
+
+ndc_resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_ndc","en","clinical/models")\
+    .setInputCols(["mpnet_embeddings"])\
+    .setOutputCol("ndc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, embedder, ndc_resolver
+])
+
+data = spark.createDataFrame([["She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner = MedicalNerModel
+    .pretrained("ner_posology_greedy", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("DRUG"))
+
+val c2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("mpnet_embeddings")
+    .setCaseSensitive(false)
+
+val ndc_resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_ndc", "en", "clinical/models")
+    .setInputCols(Array("mpnet_embeddings"))
+    .setOutputCol("ndc_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, embedder, ndc_resolver
+))
+
+val data = Seq("She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                  | entity   | ndc_code   | resolution                              | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:---------------------------|:---------|:-----------|:----------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| losartan potassium 50 mg   | DRUG     | 70010-0742 | losartan 50 mg/1 tablet                 | 70010-0742:::64380-0934:::68180-0377:::0904-7048:::59746-0334:::68180-0376:::090... | 0.3996:::0.4204:::0.4247:::0.4661:::0.4862:::0.5264:::0.5362:::0.5575:::0.5787::... | 0.0799:::0.0883:::0.0902:::0.1086:::0.1182:::0.1385:::0.1438:::0.1554:::0.1674::... | losartan 50 mg/1 tablet:::losartan potassium 50 mg:::losartan potassium 50 mg/1 ... | {'packages': "['30 TABLET in 1 BOTTLE (70010-742-03)', '90 TABLET in 1 BOTTLE (7... |
+| hydrochlorothiazide 25 mg  | DRUG     | 68645-0510 | hydrochlorothiazide 25 mg/1 tablet      | 68645-0510:::65862-0631:::62135-0669:::69097-0831:::0591-0862:::0378-6325:::0591... | 0.5349:::0.6266:::0.6398:::0.6462:::0.6675:::0.6682:::0.6699:::0.6822:::0.6859::... | 0.1430:::0.1963:::0.2047:::0.2088:::0.2228:::0.2233:::0.2244:::0.2327:::0.2352::... | hydrochlorothiazide 25 mg/1 tablet:::irbesartan and hydrochlorothiazide 25 mg/1:... | {'packages': "['30 TABLET in 1 BOTTLE (68645-510-54)']", 'alternatives': ['0172-... |
+| sertraline 50 mg           | DRUG     | 72189-0551 | sertraline hcl 50 mg/1                  | 72189-0551:::68645-0522:::76282-0213:::0904-6925:::76282-0212:::0904-6924:::6864... | 0.3778:::0.4472:::0.4638:::0.4835:::0.5591:::0.5764:::0.6186:::0.6410:::0.6586::... | 0.0714:::0.1000:::0.1075:::0.1169:::0.1563:::0.1661:::0.1913:::0.2055:::0.2169::... | sertraline hcl 50 mg/1:::sertraline hydrochloride 50 mg/1 tablet:::sertraline 50... | {'packages': "['30 TABLET, FILM COATED in 1 BOTTLE (72189-551-30)', '90 TABLET, ... |
+| metoprolol succinate 25 mg | DRUG     | 63629-8863 | metoprolol succinate er tablets 25 mg/1 | 63629-8863:::0378-0018:::61919-0754:::46708-0290:::55154-6886:::71335-0158:::467... | 0.4207:::0.4494:::0.4840:::0.5089:::0.6069:::0.6287:::0.6621:::0.6785:::0.6847::... | 0.0885:::0.1010:::0.1171:::0.1295:::0.1842:::0.1976:::0.2192:::0.2302:::0.2344::... | metoprolol succinate er tablets 25 mg/1:::metoprolol tartrate 25 mg/1:::metoprol... | {'packages': "['100 TABLET, FILM COATED, EXTENDED RELEASE in 1 BOTTLE (63629-886... |
+| gabapentin 300 mg          | DRUG     | 16714-0662 | gabapentin 300 mg/1 capsule             | 16714-0662:::65862-0199:::70771-1861:::53451-0103:::81279-0126:::68462-0126:::74... | 0.4204:::0.4424:::0.4664:::0.5558:::0.6058:::0.6689:::0.6735:::0.6870:::0.7024::... | 0.0884:::0.0978:::0.1088:::0.1544:::0.1835:::0.2237:::0.2268:::0.2360:::0.2467::... | gabapentin 300 mg/1 capsule:::gabapentin 300 mg/1:::gabapentin 300 mg/1 tablet::... | {'packages': "['100 CAPSULE in 1 BOTTLE (16714-662-01)', '500 CAPSULE in 1 BOTTL... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_ndc|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[mpnet_embeddings]|
+|Output Labels:|[ndc_code]|
+|Language:|en|
+|Size:|768.3 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-drug_brandname_ndc_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-drug_brandname_ndc_mapper_en.md
@@ -32,6 +32,7 @@ This pretrained clinical model performs the task of mapping pharmaceutical brand
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-drug_brandname_ndc_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-drug_brandname_ndc_mapper_en.md
@@ -1,0 +1,140 @@
+---
+layout: model
+title: Mapping Drug Brand Names with Corresponding National Drug Codes
+author: John Snow Labs
+name: drug_brandname_ndc_mapper
+date: 2026-07-26
+tags: [en, chunk_mapper, licensed, clinical, ndc, drug_brandname]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This pretrained clinical model performs the task of mapping pharmaceutical brand names to their corresponding National Drug Codes (NDC). The model returns product NDCs for each dosage strength in both the result and metadata fields. Trained on the openFDA NDC Directory (release 2026-07-22).
+
+{:.btn-box}
+<button class="button button-orange" disabled>Live Demo</button>
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/26.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/drug_brandname_ndc_mapper_en_6.4.0_3.4_1785026627678.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/drug_brandname_ndc_mapper_en_6.4.0_3.4_1785026627678.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("chunk")
+
+chunkerMapper = ChunkMapperModel.pretrained("drug_brandname_ndc_mapper", "en", "clinical/models")\
+    .setInputCols(["chunk"])\
+    .setOutputCol("ndc")\
+    .setRels(["Strength_NDC"])\
+    .setLowerCase(True)
+
+pipeline = Pipeline(stages=[
+    document_assembler,
+    doc2chunk,
+    chunkerMapper
+])
+
+data = spark.createDataFrame([["zytiga"], ["lipitor"], ["crestor"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("chunk")
+
+chunkerMapper = medical.ChunkMapperModel.pretrained("drug_brandname_ndc_mapper", "en", "clinical/models")\
+    .setInputCols(["chunk"])\
+    .setOutputCol("ndc")\
+    .setRels(["Strength_NDC"])\
+    .setLowerCase(True)
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler,
+    doc2chunk,
+    chunkerMapper
+])
+
+data = spark.createDataFrame([["zytiga"], ["lipitor"], ["crestor"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val doc2chunk = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("chunk")
+
+val chunkerMapper = ChunkMapperModel
+    .pretrained("drug_brandname_ndc_mapper", "en", "clinical/models")
+    .setInputCols(Array("chunk"))
+    .setOutputCol("ndc")
+    .setRels(Array("Strength_NDC"))
+    .setLowerCase(true)
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler,
+    doc2chunk,
+    chunkerMapper
+))
+
+val data = Seq("zytiga", "lipitor", "crestor").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| Brandname   | Strength_NDC         | All_K_Resolutions                                                                     |
+|:------------|:---------------------|:--------------------------------------------------------------------------------------|
+| zytiga      | 250 mg/1 | 57894-150 | 250 mg/1 | 57894-150:::500 mg/1 | 57894-195                                           |
+| lipitor     | 20 mg/1 | 58151-156  | 20 mg/1 | 58151-156:::80 mg/1 | 58151-158:::10 mg/1 | 58151-155:::40 mg/1 | 58151-157 |
+| crestor     | 10 mg/1 | 0310-7570  | 10 mg/1 | 0310-7570:::20 mg/1 | 0310-7580:::40 mg/1 | 0310-7590:::5 mg/1 | 0310-7560  |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|drug_brandname_ndc_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[chunk]|
+|Output Labels:|[ndc]|
+|Language:|en|
+|Size:|1.7 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-hcpcs_ndc_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-hcpcs_ndc_mapper_en.md
@@ -32,6 +32,7 @@ This pretrained model establishes connections between HCPCS codes and their corr
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-hcpcs_ndc_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-hcpcs_ndc_mapper_en.md
@@ -1,0 +1,137 @@
+---
+layout: model
+title: Mapping HCPCS Codes with Corresponding National Drug Codes (NDC) and Drug Brand Names
+author: John Snow Labs
+name: hcpcs_ndc_mapper
+date: 2026-07-26
+tags: [en, chunk_mapper, licensed, clinical, ndc, hcpcs]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This pretrained model establishes connections between HCPCS codes and their corresponding National Drug Codes (NDC) along with associated drug brand names. Trained on the PDAC NDC/HCPCS Crosswalk (release pdac-2026-07-05).
+
+{:.btn-box}
+<button class="button button-orange" disabled>Live Demo</button>
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/26.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hcpcs_ndc_mapper_en_6.4.0_3.4_1785072742271.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hcpcs_ndc_mapper_en_6.4.0_3.4_1785072742271.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("chunk")
+
+chunkerMapper = ChunkMapperModel.pretrained("hcpcs_ndc_mapper", "en", "clinical/models")\
+    .setInputCols(["chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["ndc_code", "brand_name"])
+
+pipeline = Pipeline(stages=[
+    document_assembler,
+    doc2chunk,
+    chunkerMapper
+])
+
+data = spark.createDataFrame([["Q5106"], ["J9211"], ["J7508"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("chunk")
+
+chunkerMapper = medical.ChunkMapperModel.pretrained("hcpcs_ndc_mapper", "en", "clinical/models")\
+    .setInputCols(["chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["ndc_code", "brand_name"])
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler,
+    doc2chunk,
+    chunkerMapper
+])
+
+data = spark.createDataFrame([["Q5106"], ["J9211"], ["J7508"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val doc2chunk = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("chunk")
+
+val chunkerMapper = ChunkMapperModel
+    .pretrained("hcpcs_ndc_mapper", "en", "clinical/models")
+    .setInputCols(Array("chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("ndc_code", "brand_name"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler,
+    doc2chunk,
+    chunkerMapper
+))
+
+val data = Seq("Q5106", "J9211", "J7508").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| HCPCS Code   | NDC Code      | Brand Name                                 | All NDC Codes                                                                                                                                                                                                                                                                 | All Brand Names                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|:-------------|:--------------|:-------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Q5106        | 00069-1305-10 | RETACRIT (PF) 2000 U/1 ML                  | 00069-1305-10:::00069-1306-10:::00069-1307-10:::00069-1308-10:::00069-1309-04:::00069-1318-10:::59353-0002-01:::59353-0002-10:::59353-0003-01:::59353-0003-10:::59353-0004-01:::59353-0004-10:::59353-0010-01:::59353-0010-10:::59353-0220-01:::59353-0220-10                 | RETACRIT (PF) 2000 U/1 ML:::RETACRIT (PF) 3000 U/1 ML:::RETACRIT (PF) 4000 U/1 ML:::RETACRIT (PF) 10000 U/1 ML:::RETACRIT (PF) 40000 U/1 ML:::RETACRIT (10X2ML;MDV,LATEX-FREE) 10000 U/1 ML:::RETACRIT (PF) 2000 U/1 ML:::RETACRIT (PF) 2000 U/1 ML:::RETACRIT (PF) 3000 U/1 ML:::RETACRIT (PF) 3000 U/1 ML:::RETACRIT (PF) 4000 U/1 ML:::RETACRIT (PF) 4000 U/1 ML:::RETACRIT (PF) 10000 U/1 ML:::RETACRIT (PF) 10000 U/1 ML:::RETACRIT  10000 U/1 ML:::RETACRIT  10000 U/1 ML                                                                                                                                                                                                                                                                                            |
+| J9211        | 00013-2576-05 | IDAMYCIN PFS (SDV,PF,LATEX-FREE) 1 MG/1 ML | 00013-2576-05:::00013-2576-91:::00013-2586-10:::00013-2586-91:::00013-2596-20:::00143-9217-01:::00143-9218-01:::00143-9219-01:::00143-9306-01:::00143-9307-01:::00143-9308-01:::59762-2576-01:::59762-2586-01:::59762-2596-01:::71288-0184-05:::71288-0185-10:::71288-0186-20 | IDAMYCIN PFS (SDV,PF,LATEX-FREE) 1 MG/1 ML:::IDAMYCIN PFS (SDV,PF,CYTOSAFE VIAL,PF) 1 MG/ML:::IDAMYCIN PFS (GLASS SDV,PF,LATEX-FREE) 1 MG/1 ML:::IDAMYCIN PFS (SDV.PF,CYTOSAFE VIAL,PF) 1 MG/ML:::IDAMYCIN PFS (GLASS SDV,PF,LATEX-FREE) 1 MG/1 ML:::IDARUBICIN HYDROCHLORIDE (PF) 1 MG/1 ML:::IDARUBICIN HYDROCHLORIDE (PF) 1 MG/1 ML:::IDARUBICIN HYDROCHLORIDE (PF) 1 MG/1 ML:::IDARUBICIN HCL NOVAPLUS (SDV,PF) 1 MG/1 ML:::IDARUBICIN HCL NOVAPLUS (SDV,PF) 1 MG/1 ML:::IDARUBICIN HCL NOVAPLUS (SDV,PF) 1 MG/1 ML:::IDARUBICIN HYDROCHLORIDE (PF) 1 MG/ML:::IDARUBICIN HYDROCHLORIDE (PF) 1 MG/ML:::IDARUBICIN HYDROCHLORIDE (PF) 1 MG/ML:::IDARUBICIN HYDROCHLORIDE SDV 1 MG/1 ML:::IDARUBICIN HYDROCHLORIDE SDV 1 MG/1 ML:::IDARUBICIN HYDROCHLORIDE SDV 1 MG/1 ML |
+| J7508        | 00469-0647-73 | ASTAGRAF XL 0.5 MG                         | 00469-0647-73:::00469-0677-73:::00469-0687-73:::69238-2780-03:::69238-2781-03:::69238-2782-03                                                                                                                                                                                 | ASTAGRAF XL 0.5 MG:::ASTAGRAF XL 1 MG:::ASTAGRAF XL 5 MG:::TACROLIMUS HARD GELATIN 0.5 MG:::TACROLIMUS HARD GELATIN 1 MG:::TACROLIMUS HARD GELATIN 5 MG                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hcpcs_ndc_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|99.1 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_drug_brandname_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_drug_brandname_mapper_en.md
@@ -1,0 +1,136 @@
+---
+layout: model
+title: Mapping National Drug Codes (NDC) Codes with Corresponding Drug Brand Names
+author: John Snow Labs
+name: ndc_drug_brandname_mapper
+date: 2026-07-26
+tags: [en, chunk_mapper, licensed, clinical, ndc, drug_brandname]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This pretrained model maps National Drug Codes (NDC) codes with their corresponding drug brand names. Trained on the openFDA NDC Directory (release 2026-07-22).
+
+{:.btn-box}
+<button class="button button-orange" disabled>Live Demo</button>
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/26.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/ndc_drug_brandname_mapper_en_6.4.0_3.4_1785071156813.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/ndc_drug_brandname_mapper_en_6.4.0_3.4_1785071156813.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("chunk")
+
+chunkerMapper = ChunkMapperModel.pretrained("ndc_drug_brandname_mapper", "en", "clinical/models")\
+    .setInputCols(["chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["drug_brand_name"])
+
+pipeline = Pipeline(stages=[
+    document_assembler,
+    doc2chunk,
+    chunkerMapper
+])
+
+data = spark.createDataFrame([["57894-150"], ["0363-0221"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("chunk")
+
+chunkerMapper = medical.ChunkMapperModel.pretrained("ndc_drug_brandname_mapper", "en", "clinical/models")\
+    .setInputCols(["chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["drug_brand_name"])
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler,
+    doc2chunk,
+    chunkerMapper
+])
+
+data = spark.createDataFrame([["57894-150"], ["0363-0221"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val doc2chunk = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("chunk")
+
+val chunkerMapper = ChunkMapperModel
+    .pretrained("ndc_drug_brandname_mapper", "en", "clinical/models")
+    .setInputCols(Array("chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("drug_brand_name"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler,
+    doc2chunk,
+    chunkerMapper
+))
+
+val data = Seq("57894-150", "0363-0221").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| NDC Code   | drug_brand_name   |
+|:-----------|:------------------|
+| 57894-150  | Zytiga            |
+| 0363-0221  | Ibuprofen         |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|ndc_drug_brandname_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[chunk]|
+|Output Labels:|[brandname]|
+|Language:|en|
+|Size:|2.7 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_drug_brandname_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_drug_brandname_mapper_en.md
@@ -32,6 +32,7 @@ This pretrained model maps National Drug Codes (NDC) codes with their correspond
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_hcpcs_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_hcpcs_mapper_en.md
@@ -1,0 +1,137 @@
+---
+layout: model
+title: Mapping National Drug Codes (NDC) with Corresponding HCPCS Codes and Descriptions
+author: John Snow Labs
+name: ndc_hcpcs_mapper
+date: 2026-07-26
+tags: [en, chunk_mapper, licensed, clinical, ndc, hcpcs]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This pretrained model establishes mappings between National Drug Codes and their corresponding HCPCS codes along with descriptions. Trained on the PDAC NDC/HCPCS Crosswalk (release pdac-2026-07-05).
+
+{:.btn-box}
+<button class="button button-orange" disabled>Live Demo</button>
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/26.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/ndc_hcpcs_mapper_en_6.4.0_3.4_1785072058210.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/ndc_hcpcs_mapper_en_6.4.0_3.4_1785072058210.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("chunk")
+
+chunkerMapper = ChunkMapperModel.pretrained("ndc_hcpcs_mapper", "en", "clinical/models")\
+    .setInputCols(["chunk"])\
+    .setOutputCol("hcpcs")\
+    .setRels(["hcpcs_code", "hcpcs_description"])
+
+pipeline = Pipeline(stages=[
+    document_assembler,
+    doc2chunk,
+    chunkerMapper
+])
+
+data = spark.createDataFrame([["16714-0892-01"], ["00990-6138-03"], ["43598-0650-11"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("chunk")
+
+chunkerMapper = medical.ChunkMapperModel.pretrained("ndc_hcpcs_mapper", "en", "clinical/models")\
+    .setInputCols(["chunk"])\
+    .setOutputCol("hcpcs")\
+    .setRels(["hcpcs_code", "hcpcs_description"])
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler,
+    doc2chunk,
+    chunkerMapper
+])
+
+data = spark.createDataFrame([["16714-0892-01"], ["00990-6138-03"], ["43598-0650-11"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val doc2chunk = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("chunk")
+
+val chunkerMapper = ChunkMapperModel
+    .pretrained("ndc_hcpcs_mapper", "en", "clinical/models")
+    .setInputCols(Array("chunk"))
+    .setOutputCol("hcpcs")
+    .setRels(Array("hcpcs_code", "hcpcs_description"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler,
+    doc2chunk,
+    chunkerMapper
+))
+
+val data = Seq("16714-0892-01", "00990-6138-03", "43598-0650-11").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| NDC Code      | HCPCS Code   | HCPCS Description                                  |
+|:--------------|:-------------|:---------------------------------------------------|
+| 16714-0892-01 | J0878        | INJECTION, DAPTOMYCIN, 1 MG                        |
+| 00990-6138-03 | A4217        | STERILE WATER/SALINE, 500 ML                       |
+| 43598-0650-11 | J9342        | INJECTION, THIOTEPA, NOT OTHERWISE SPECIFIED, 1 MG |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|ndc_hcpcs_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|179.2 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_hcpcs_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_hcpcs_mapper_en.md
@@ -32,6 +32,7 @@ This pretrained model establishes mappings between National Drug Codes and their
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_mapper_en.md
@@ -32,6 +32,7 @@ This model maps drug entities extracted from clinical text to their correspondin
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-ndc_mapper_en.md
@@ -1,0 +1,183 @@
+---
+layout: model
+title: Mapping Entities with Corresponding NDC Codes
+author: John Snow Labs
+name: ndc_mapper
+date: 2026-07-26
+tags: [en, chunk_mapper, licensed, clinical, ndc]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps drug entities extracted from clinical text to their corresponding National Drug Codes (NDC). It uses ner_posology_greedy for drug entity recognition and provides fast code mapping without requiring embeddings at inference time. Trained on the openFDA NDC Directory (release 2026-07-22).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/ndc_mapper_en_6.4.0_3.4_1785090677195.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/ndc_mapper_en_6.4.0_3.4_1785090677195.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("embeddings")
+
+ner_posology = MedicalNerModel.pretrained("ner_posology_greedy", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "embeddings"])\
+    .setOutputCol("posology_ner")
+
+ner_posology_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "posology_ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+ndc_mapper = ChunkMapperModel.pretrained("ndc_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["ndc_code"])
+
+pipeline = Pipeline(stages=[
+    document_assembler, sentence_detector, tokenizer, word_embeddings,
+    ner_posology, ner_posology_converter, ndc_mapper
+])
+data = spark.createDataFrame([["She was started on amoxicillin 500 mg three times daily for a bacterial sinus infection, continues aspirin 81 mg once daily for cardiovascular prophylaxis, takes acetaminophen 500 mg as needed for pain, and was also prescribed cetirizine hydrochloride 10 mg once daily for seasonal allergies."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("embeddings")
+
+ner_posology = medical.NerModel.pretrained("ner_posology_greedy", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "embeddings"])\
+    .setOutputCol("posology_ner")
+
+ner_posology_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "posology_ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+ndc_mapper = medical.ChunkMapperModel.pretrained("ndc_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["ndc_code"])
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentence_detector, tokenizer, word_embeddings,
+    ner_posology, ner_posology_converter, ndc_mapper
+])
+data = spark.createDataFrame([["She was started on amoxicillin 500 mg three times daily for a bacterial sinus infection, continues aspirin 81 mg once daily for cardiovascular prophylaxis, takes acetaminophen 500 mg as needed for pain, and was also prescribed cetirizine hydrochloride 10 mg once daily for seasonal allergies."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols("document")
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val wordEmbeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val nerPosology = MedicalNerModel.pretrained("ner_posology_greedy", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("posology_ner")
+
+val nerPosologyConverter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "posology_ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("DRUG"))
+
+val ndcMapper = ChunkMapperModel.pretrained("ndc_mapper", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("ndc_code"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, wordEmbeddings,
+    nerPosology, nerPosologyConverter, ndcMapper
+))
+
+val data = Seq("She was started on amoxicillin 500 mg three times daily for a bacterial sinus infection, continues aspirin 81 mg once daily for cardiovascular prophylaxis, takes acetaminophen 500 mg as needed for pain, and was also prescribed cetirizine hydrochloride 10 mg once daily for seasonal allergies.").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                      | ndc_code   |
+|:-------------------------------|:-----------|
+| amoxicillin 500 mg             | 83112-0500 |
+| aspirin 81 mg                  | 41250-0780 |
+| acetaminophen 500 mg           | 69618-0011 |
+| cetirizine hydrochloride 10 mg | 66424-0564 |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|ndc_mapper|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|8.3 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-sbiobertresolve_ndc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-sbiobertresolve_ndc_en.md
@@ -1,0 +1,219 @@
+---
+layout: model
+title: Sentence Entity Resolver for NDC (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_ndc
+date: 2026-07-26
+tags: [en, entity_resolution, licensed, clinical, ndc, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.0
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical entities and concepts, particularly drugs and ingredients, to National Drug Codes. It leverages `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings and provides package options plus alternative drug suggestions through the `all_k_aux_label` column. Trained on the openFDA NDC Directory (release 2026-07-22).
+
+{:.btn-box}
+[Live Demo](https://demo.johnsnowlabs.com/healthcare/ER_NDC/){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/26.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_ndc_en_6.4.0_3.4_1785025436584.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_ndc_en_6.4.0_3.4_1785025436584.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner = MedicalNerModel.pretrained("ner_posology_greedy","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+sbert_embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx","en","clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+ndc_resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_ndc","en","clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("ndc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, sbert_embedder, ndc_resolver
+])
+
+data = spark.createDataFrame([["She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner = medical.NerModel.pretrained("ner_posology_greedy","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+sbert_embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx","en","clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+ndc_resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_ndc","en","clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("ndc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, sbert_embedder, ndc_resolver
+])
+
+data = spark.createDataFrame([["She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner = MedicalNerModel
+    .pretrained("ner_posology_greedy", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("DRUG"))
+
+val c2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val sbert_embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en","clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sentence_embeddings")
+    .setCaseSensitive(false)
+
+val ndc_resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_ndc", "en", "clinical/models")
+    .setInputCols(Array("sentence_embeddings"))
+    .setOutputCol("ndc_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner, ner_converter, c2doc, sbert_embedder, ndc_resolver
+))
+
+val data = Seq("She was started on losartan potassium 50 mg and hydrochlorothiazide 25 mg once daily for blood pressure control, continues sertraline 50 mg for depression, was switched to metoprolol succinate 25 mg for rate control, and takes gabapentin 300 mg at bedtime for neuropathic pain.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                  | entity   | ndc_code   | resolution                   | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:---------------------------|:---------|:-----------|:-----------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| losartan potassium 50 mg   | DRUG     | 64380-0934 | losartan potassium 50 mg     | 64380-0934:::0904-7048:::59746-0334:::63187-0071:::70010-0742:::68180-0377:::059... | 0.0000:::3.4537:::4.1715:::4.3757:::5.5351:::6.5793:::7.1780:::7.4024:::7.5303::... | 0.0000:::0.0197:::0.0280:::0.0317:::0.0506:::0.0719:::0.0851:::0.0903:::0.0948::... | losartan potassium 50 mg:::losartan potassium 50 mg/1:::losartan potassium table... | {'packages': "['30 TABLET, FILM COATED in 1 BOTTLE (64380-934-04)', '90 TABLET, ... |
+| hydrochlorothiazide 25 mg  | DRUG     | 68645-0510 | hydrochlorothiazide 25 mg/1  | 68645-0510:::46708-0211:::0591-0424:::0378-0614:::50111-0327:::0517-4201:::0378-... | 3.3059:::5.6094:::5.7282:::5.9631:::6.1827:::6.3636:::6.3982:::6.5080:::6.5657::... | 0.0198:::0.0578:::0.0607:::0.0643:::0.0681:::0.0708:::0.0757:::0.0786:::0.0794::... | hydrochlorothiazide 25 mg/1:::telmisartan and hydrochlorothiazide 25 mg/1:::tria... | {'packages': "['30 TABLET in 1 BOTTLE (68645-510-54)']", 'alternatives': ['0172-... |
+| sertraline 50 mg           | DRUG     | 76282-0213 | sertraline 50 mg/1           | 76282-0213:::72189-0551:::0135-0550:::73352-0835:::21922-0107:::64896-0403:::090... | 4.2370:::4.6930:::5.9452:::6.0866:::6.1552:::6.2522:::6.3589:::6.4492:::6.5168::... | 0.0288:::0.0351:::0.0563:::0.0593:::0.0599:::0.0640:::0.0658:::0.0669:::0.0679::... | sertraline 50 mg/1:::sertraline hcl 50 mg/1:::sensodyne 50 mg/g:::tridacaine iii... | {'packages': "['100 TABLET, FILM COATED in 1 BOTTLE (76282-213-01)', '500 TABLET... |
+| metoprolol succinate 25 mg | DRUG     | 55111-0466 | metoprolol succinate 25 mg/1 | 55111-0466:::61919-0754:::0378-0018:::46708-0290:::63629-8863:::54766-0726:::831... | 3.6995:::4.0826:::4.7247:::5.5334:::5.6337:::6.2463:::6.4721:::6.6422:::6.7591::... | 0.0252:::0.0307:::0.0404:::0.0559:::0.0572:::0.0707:::0.0744:::0.0767:::0.0808::... | metoprolol succinate 25 mg/1:::metoprolol succinate er 25 mg/1:::metoprolol tart... | {'packages': "['100 TABLET, FILM COATED, EXTENDED RELEASE in 1 BOTTLE (55111-466... |
+| gabapentin 300 mg          | DRUG     | 65862-0199 | gabapentin 300 mg/1          | 65862-0199:::53451-0103:::16714-0662:::70771-1519:::70771-1861:::55111-0428:::54... | 3.4135:::4.9239:::5.4970:::6.7556:::6.9104:::7.1170:::7.2007:::7.2374:::7.2745::... | 0.0189:::0.0396:::0.0493:::0.0758:::0.0777:::0.0838:::0.0854:::0.0862:::0.0864::... | gabapentin 300 mg/1:::gabapentin enacarbil 300 mg/1:::gabapentin 300 mg/1 capsul... | {'packages': "['2000 CAPSULE in 1 BAG (65862-199-26)', '100 CAPSULE in 1 BOTTLE ... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_ndc|
+|Compatibility:|Healthcare NLP 6.4.0+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sentence_embeddings]|
+|Output Labels:|[ndc_code]|
+|Language:|en|
+|Size:|766.5 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-26-sbiobertresolve_ndc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-26-sbiobertresolve_ndc_en.md
@@ -32,6 +32,7 @@ This model maps clinical entities and concepts, particularly drugs and ingredien
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 documentAssembler = DocumentAssembler()\


### PR DESCRIPTION
## NDC 20260722 — Resolver & Mapper Models

### Resolvers (3)
| Model | Status |
|---|---|
| `sbiobertresolve_ndc` | Updated |
| `biolordresolve_ndc` | New |
| `bgeresolve_ndc` | New |

Trained on the openFDA NDC Directory (release 2026-07-22).

### Mappers (5)
| Model | Direction | Status |
|---|---|---|
| `drug_brandname_ndc_mapper` | brand name → NDC | Updated |
| `ndc_drug_brandname_mapper` | NDC → brand name | Updated |
| `ndc_hcpcs_mapper` | NDC → HCPCS code + description | Updated |
| `hcpcs_ndc_mapper` | HCPCS → NDC + brand name | Updated |
| `ndc_mapper` | free text → NDC (NER-based) | New |

`drug_brandname_ndc_mapper`/`ndc_drug_brandname_mapper` trained on the openFDA NDC Directory (release 2026-07-22). `ndc_hcpcs_mapper`/`hcpcs_ndc_mapper` trained on the PDAC NDC/HCPCS Crosswalk (release pdac-2026-07-05). `ndc_mapper` trained on the openFDA NDC Directory (release 2026-07-22).
