### PR TITLE
2026-07-30-sbiobertresolve_atc_en

### DIFF
--- a/docs/_posts/ozgurcaglayan1981/2026-07-30-atc_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-30-atc_mapper_en.md
@@ -1,0 +1,182 @@
+---
+layout: model
+title: Mapping Entities with Corresponding ATC Codes
+author: John Snow Labs
+name: atc_mapper
+date: 2026-07-30
+tags: [en, chunk_mapper, licensed, clinical, atc]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps drug entities extracted from clinical text to their corresponding ATC (Anatomic Therapeutic Chemical) codes. It uses ner_posology for drug entity recognition and provides fast code mapping without requiring embeddings at inference time. Trained on the WHO ATC-DDD dataset (release 2026-04-25).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/atc_mapper_en_6.4.1_3.4_1785445723495.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/atc_mapper_en_6.4.1_3.4_1785445723495.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+ner_posology = MedicalNerModel.pretrained("ner_posology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+atc_mapper = ChunkMapperModel.pretrained("atc_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["atc_code"])
+
+pipeline = Pipeline(stages=[
+    document_assembler, sentence_detector, tokenizer, word_embeddings,
+    ner_posology, ner_converter, atc_mapper
+])
+data = spark.createDataFrame([["The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+ner_posology = medical.NerModel.pretrained("ner_posology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+atc_mapper = medical.ChunkMapperModel.pretrained("atc_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["atc_code"])
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentence_detector, tokenizer, word_embeddings,
+    ner_posology, ner_converter, atc_mapper
+])
+data = spark.createDataFrame([["The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val wordEmbeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val nerPosology = MedicalNerModel.pretrained("ner_posology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val nerConverter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("DRUG"))
+
+val atcMapper = ChunkMapperModel.pretrained("atc_mapper", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("atc_code"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, wordEmbeddings,
+    nerPosology, nerConverter, atcMapper
+))
+
+val data = Seq("The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection.").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk    | atc_code   |
+|:-------------|:-----------|
+| metformin    | A10BA02    |
+| atorvastatin | C10AA05    |
+| amoxicillin  | J01CA04    |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|atc_mapper|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|811.0 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-30-atc_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-30-atc_mapper_en.md
@@ -32,6 +32,7 @@ This model maps drug entities extracted from clinical text to their correspondin
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-30-bgeresolve_atc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-30-bgeresolve_atc_en.md
@@ -32,6 +32,7 @@ This model maps drugs entities to ATC (Anatomic Therapeutic Chemical) codes usin
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-30-bgeresolve_atc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-30-bgeresolve_atc_en.md
@@ -1,0 +1,212 @@
+---
+layout: model
+title: Sentence Entity Resolver for ATC (bge_base_en_v1_5_onnx embeddings)
+author: John Snow Labs
+name: bgeresolve_atc
+date: 2026-07-30
+tags: [en, entity_resolution, licensed, clinical, atc, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps drugs entities to ATC (Anatomic Therapeutic Chemical) codes using `bge_base_en_v1_5_onnx` Sentence Embeddings. Trained on the WHO ATC-DDD dataset (release 2026-04-25).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_atc_en_6.4.1_3.4_1785445055939.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_atc_en_6.4.1_3.4_1785445055939.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+posology_ner = MedicalNerModel.pretrained("ner_posology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+atc_resolver = SentenceEntityResolverModel.pretrained("bgeresolve_atc", "en", "clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("atc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, embedder, atc_resolver
+])
+
+data = spark.createDataFrame([["The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+posology_ner = medical.NerModel.pretrained("ner_posology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+atc_resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_atc", "en", "clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("atc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, embedder, atc_resolver
+])
+
+data = spark.createDataFrame([["The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val posology_ner = MedicalNerModel.pretrained("ner_posology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("DRUG"))
+
+val c2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val atc_resolver = SentenceEntityResolverModel.pretrained("bgeresolve_atc", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("atc_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, embedder, atc_resolver
+))
+
+val data = Seq("The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk    | entity   | atc_code   | resolution   | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:-------------|:---------|:-----------|:-------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| metformin    | DRUG     | A10BA02    | metformin    | A10BA02:::A10BB07:::A10BD07:::A10BD13:::A10BD14:::A10BH04:::A10BD10:::A10BD17:::... | 0.0000:::0.5619:::0.5648:::0.5930:::0.6003:::0.6014:::0.6034:::0.6121:::0.6125::... | 0.0000:::0.1579:::0.1595:::0.1758:::0.1802:::0.1808:::0.1820:::0.1873:::0.1876::... | metformin :::glipizide / metformin :::metformin / sitagliptin :::metformin and a... | ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::... |
+| atorvastatin | DRUG     | C10AA05    | atorvastatin | C10AA05:::C10BA05:::C10AA02:::C10BX03:::C10AA04:::C10AA06:::C10BX08:::C10BA08:::... | 0.0000:::0.6086:::0.6206:::0.6311:::0.6335:::0.6591:::0.6618:::0.6680:::0.6759::... | 0.0000:::0.1852:::0.1926:::0.1992:::0.2006:::0.2172:::0.2190:::0.2231:::0.2284::... | atorvastatin:::atorvastatin / ezetimibe :::lovastatin:::amlodipine / atorvastati... | ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::... |
+| amoxicillin  | DRUG     | J01CA04    | amoxicillin  | J01CA04:::J01CR02:::R05CB02                                                         | 0.0000:::0.5697:::0.5825                                                            | 0.0000:::0.1623:::0.1696                                                            | amoxicillin:::amoxicillin and enzyme inhibitor:::amoxicillin / bromhexine           | ATC 5th:::ATC 5th:::ATC 5th                                                         |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_atc|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[atc_code]|
+|Language:|en|
+|Size:|110.3 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-30-biolordresolve_atc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-30-biolordresolve_atc_en.md
@@ -1,0 +1,212 @@
+---
+layout: model
+title: Sentence Entity Resolver for ATC (mpnet_embeddings_biolord_2023_c embeddings)
+author: John Snow Labs
+name: biolordresolve_atc
+date: 2026-07-30
+tags: [en, entity_resolution, licensed, clinical, atc, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps drugs entities to ATC (Anatomic Therapeutic Chemical) codes using `mpnet_embeddings_biolord_2023_c` Sentence Embeddings. Trained on the WHO ATC-DDD dataset (release 2026-04-25).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_atc_en_6.4.1_3.4_1785444626580.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_atc_en_6.4.1_3.4_1785444626580.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+posology_ner = MedicalNerModel.pretrained("ner_posology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)
+
+atc_resolver = SentenceEntityResolverModel.pretrained("biolordresolve_atc", "en", "clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("atc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, embedder, atc_resolver
+])
+
+data = spark.createDataFrame([["The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+posology_ner = medical.NerModel.pretrained("ner_posology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)
+
+atc_resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_atc", "en", "clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("atc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, embedder, atc_resolver
+])
+
+data = spark.createDataFrame([["The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val posology_ner = MedicalNerModel.pretrained("ner_posology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("DRUG"))
+
+val c2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("embeddings")
+    .setCaseSensitive(false)
+
+val atc_resolver = SentenceEntityResolverModel.pretrained("biolordresolve_atc", "en", "clinical/models")
+    .setInputCols(Array("embeddings"))
+    .setOutputCol("atc_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, embedder, atc_resolver
+))
+
+val data = Seq("The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk    | entity   | atc_code   | resolution   | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:-------------|:---------|:-----------|:-------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| metformin    | DRUG     | A10BA02    | metformin    | A10BA02:::A10BD18:::A10BD28:::A10BD13:::A10BD11:::A10BD15:::A10BD20:::A10BD10:::... | 0.4268:::0.6164:::0.6204:::0.6258:::0.6401:::0.6488:::0.6597:::0.6606:::0.6607::... | 0.0911:::0.1900:::0.1924:::0.1958:::0.2049:::0.2105:::0.2176:::0.2182:::0.2183::... | metformin:::metformin and gemigliptin:::metformin and teneligliptin:::metformin ... | ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::... |
+| atorvastatin | DRUG     | C10AA05    | atorvastatin | C10AA05:::C10BX03:::C10BA05:::C08CA01:::C10BA08:::C10BA16:::C10BX15:::C10AA06:::... | 0.2489:::0.6609:::0.6776:::0.7015:::0.7122:::0.7166:::0.7603:::0.7766:::0.7800::... | 0.0310:::0.2184:::0.2296:::0.2461:::0.2536:::0.2568:::0.2890:::0.3016:::0.3042::... | atorvastatin:::atorvastatin and amlodipine:::atorvastatin and ezetimibe:::Amlodi... | ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::... |
+| amoxicillin  | DRUG     | J01CA04    | amoxicillin  | J01CA04:::J01CA20:::J01CF01:::J01CA01                                               | 0.3625:::0.6792:::0.7027:::0.7258                                                   | 0.0657:::0.2307:::0.2469:::0.2634                                                   | amoxicillin:::amoxicillin / clavulanate Oral Tablet:::dicloxacillin :::ampicilli... | ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th                                               |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_atc|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[atc_code]|
+|Language:|en|
+|Size:|110.4 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-30-biolordresolve_atc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-30-biolordresolve_atc_en.md
@@ -32,6 +32,7 @@ This model maps drugs entities to ATC (Anatomic Therapeutic Chemical) codes usin
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-07-30-sbiobertresolve_atc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-30-sbiobertresolve_atc_en.md
@@ -1,0 +1,194 @@
+---
+layout: model
+title: Sentence Entity Resolver for ATC (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_atc
+date: 2026-07-30
+tags: [en, entity_resolution, licensed, clinical, atc, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps drugs entities to ATC (Anatomic Therapeutic Chemical) codes using `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings. Trained on the WHO ATC-DDD dataset (release 2026-04-25).
+
+{:.btn-box}
+[Live Demo](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_atc_en_6.4.1_3.4_1785443296843.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_atc_en_6.4.1_3.4_1785443296843.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler().setInputCol("text").setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer().setInputCols(["sentence"]).setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+posology_ner = MedicalNerModel.pretrained("ner_posology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = Chunk2Doc().setInputCols("ner_chunk").setOutputCol("ner_chunk_doc")
+
+sbert_embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+atc_resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_atc", "en", "clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("atc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, sbert_embedder, atc_resolver
+])
+
+data = spark.createDataFrame([["The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler().setInputCol("text").setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer().setInputCols(["sentence"]).setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+posology_ner = medical.NerModel.pretrained("ner_posology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["DRUG"])
+
+c2doc = nlp.Chunk2Doc().setInputCols("ner_chunk").setOutputCol("ner_chunk_doc")
+
+sbert_embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+atc_resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_atc", "en", "clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("atc_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, sbert_embedder, atc_resolver
+])
+
+data = spark.createDataFrame([["The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler().setInputCol("text").setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer().setInputCols("sentence").setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val posology_ner = MedicalNerModel.pretrained("ner_posology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("DRUG"))
+
+val c2doc = new Chunk2Doc().setInputCols("ner_chunk").setOutputCol("ner_chunk_doc")
+
+val sbert_embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en","clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sentence_embeddings")
+    .setCaseSensitive(false)
+
+val atc_resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_atc", "en", "clinical/models")
+    .setInputCols(Array("sentence_embeddings"))
+    .setOutputCol("atc_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    posology_ner, ner_converter, c2doc, sbert_embedder, atc_resolver
+))
+
+val data = Seq("The patient was started on metformin 500 mg twice daily for type 2 diabetes and was also prescribed atorvastatin for hyperlipidemia. She was given amoxicillin for a sinus infection.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk    | entity   | atc_code   | resolution   | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:-------------|:---------|:-----------|:-------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| metformin    | DRUG     | A10BA02    | metformin    | A10BA02:::A10BA01:::A10BB01:::A10BD17:::A10BD02:::A10BH04:::A10BD13:::J05AA01:::... | 0.0000:::8.3109:::8.5307:::8.6477:::8.8556:::8.9024:::9.3279:::9.3832:::9.4126::... | 0.0000:::0.1134:::0.1192:::0.1236:::0.1274:::0.1309:::0.1439:::0.1445:::0.1451::... | metformin:::phenformin :::glyburide / metformin :::metformin and acarbose:::metf... | ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::... |
+| atorvastatin | DRUG     | C10AA05    | atorvastatin | C10AA05:::C10AA07:::C10AA06:::C10BX08:::C10AA03:::C10AA04:::C10BX15:::C10AA02:::... | 0.0000:::6.1618:::6.2856:::7.4259:::7.4874:::7.5918:::7.6736:::7.7381:::8.0282::... | 0.0000:::0.0667:::0.0695:::0.1002:::0.0980:::0.1013:::0.1076:::0.1058:::0.1183::... | atorvastatin :::rosuvastatin :::cerivastatin :::atorvastatin and acetylsalicylic... | ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::... |
+| amoxicillin  | DRUG     | J01CA04    | amoxicillin  | J01CA04:::S01AA19:::J01CA01:::J01CF02:::J01CF01:::J01CF05:::J01CA19:::J01CA51:::... | 0.0000:::6.9141:::6.9141:::7.4772:::7.6220:::7.6735:::7.8381:::7.8753:::7.8847      | 0.0000:::0.0820:::0.0820:::0.0967:::0.1006:::0.1002:::0.1101:::0.1082:::0.1119      | amoxicillin:::ampicillin:::ampicillin :::cloxacillin :::dicloxacillin :::fluclox... | ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::ATC 5th:::... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_atc|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sentence_embeddings]|
+|Output Labels:|[atc_code]|
+|Language:|en|
+|Size:|110.1 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-07-30-sbiobertresolve_atc_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-07-30-sbiobertresolve_atc_en.md
@@ -32,6 +32,7 @@ This model maps drugs entities to ATC (Anatomic Therapeutic Chemical) codes usin
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler().setInputCol("text").setOutputCol("document")

--- a/docs/_posts/ozgurcaglayan1981/2026-08-04-bgeresolve_ncit_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-04-bgeresolve_ncit_en.md
@@ -1,0 +1,215 @@
+---
+layout: model
+title: Sentence Entity Resolver for NCI-t (bge_base_en_v1_5_onnx embeddings)
+author: John Snow Labs
+name: bgeresolve_ncit
+date: 2026-08-04
+tags: [en, entity_resolution, licensed, clinical, ncit, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/oncology entities to NCIt (NCI Thesaurus) codes using `bge_base_en_v1_5_onnx` Sentence Embeddings. Trained on the NCI Thesaurus dataset (July 28, 2026 release).
+
+{:.btn-box}
+[Live Demo](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_ncit_en_6.4.1_3.4_1785880039155.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_ncit_en_6.4.1_3.4_1785880039155.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+oncology_ner = MedicalNerModel.pretrained("ner_oncology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setBlackList(["Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                    "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"])
+
+c2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+sbert_embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en") \
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+ncit_resolver = SentenceEntityResolverModel.pretrained("bgeresolve_ncit", "en", "clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+])
+
+data = spark.createDataFrame([["The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+oncology_ner = medical.NerModel.pretrained("ner_oncology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setBlackList(["Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                    "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"])
+
+c2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+sbert_embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en") \
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+ncit_resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_ncit", "en", "clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+])
+
+data = spark.createDataFrame([["The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val oncology_ner = MedicalNerModel.pretrained("ner_oncology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setBlackList(Array("Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                         "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"))
+
+val c2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val sbert_embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val ncit_resolver = SentenceEntityResolverModel.pretrained("bgeresolve_ncit", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+))
+
+val data = Seq("The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk        | entity         | ncit_code   | resolution_text                     | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:-----------------|:---------------|:------------|:------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| breast carcinoma | Cancer_Dx      | C4872       | breast carcinoma [breast carcinoma] | C4872:::C4017:::C118809:::C2910:::C2918:::C9335:::C5214:::C9245:::C2916:::C16264... | 0.0000:::0.3921:::0.4018:::0.4583:::0.4678:::0.5308:::0.5342:::0.5486:::0.5512::... | 0.0000:::0.0769:::0.0807:::0.1050:::0.1094:::0.1409:::0.1427:::0.1505:::0.1519::... | breast carcinoma [breast carcinoma]:::breast ductal carcinoma [breast ductal car... |
+| biopsy           | Pathology_Test | C15189      | biopsy [biopsy]                     | C15189:::C15385:::C51692:::C51698:::C192621:::C51748:::C51699:::C51678:::C77677:... | 0.0000:::0.4025:::0.4440:::0.4530:::0.4538:::0.4771:::0.4821:::0.4857:::0.4929::... | 0.0000:::0.0810:::0.0986:::0.1026:::0.1030:::0.1138:::0.1162:::0.1180:::0.1215::... | biopsy [biopsy]:::surgical biopsy [surgical biopsy]:::skin biopsy [skin biopsy]:... |
+| chemotherapy     | Chemotherapy   | C15632      | chemotherapy [chemotherapy]         | C15632:::C226697:::C191:::C174557:::C1594:::C158803:::C15807:::C51967:::C180666:... | 0.0000:::0.4523:::0.5313:::0.5667:::0.5671:::0.5676:::0.5717:::0.5764:::0.5779::... | 0.0000:::0.1023:::0.1411:::0.1606:::0.1608:::0.1611:::0.1634:::0.1661:::0.1670::... | chemotherapy [chemotherapy]:::chemotherapy answer [chemotherapy answer]:::chemot... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_ncit|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|1.7 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-04-bgeresolve_ncit_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-04-bgeresolve_ncit_en.md
@@ -32,6 +32,7 @@ This model maps clinical/oncology entities to NCIt (NCI Thesaurus) codes using `
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-08-04-biolordresolve_ncit_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-04-biolordresolve_ncit_en.md
@@ -32,6 +32,7 @@ This model maps clinical/oncology entities to NCIt (NCI Thesaurus) codes using `
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-08-04-biolordresolve_ncit_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-04-biolordresolve_ncit_en.md
@@ -1,0 +1,215 @@
+---
+layout: model
+title: Sentence Entity Resolver for NCI-t (mpnet_embeddings_biolord_2023_c embeddings)
+author: John Snow Labs
+name: biolordresolve_ncit
+date: 2026-08-04
+tags: [en, entity_resolution, licensed, clinical, ncit, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/oncology entities to NCIt (NCI Thesaurus) codes using `mpnet_embeddings_biolord_2023_c` Sentence Embeddings. Trained on the NCI Thesaurus dataset (July 28, 2026 release).
+
+{:.btn-box}
+[Live Demo](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_ncit_en_6.4.1_3.4_1785879314968.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_ncit_en_6.4.1_3.4_1785879314968.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+oncology_ner = MedicalNerModel.pretrained("ner_oncology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setBlackList(["Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                    "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"])
+
+c2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+sbert_embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en") \
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)
+
+ncit_resolver = SentenceEntityResolverModel.pretrained("biolordresolve_ncit", "en", "clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+])
+
+data = spark.createDataFrame([["The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+oncology_ner = medical.NerModel.pretrained("ner_oncology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setBlackList(["Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                    "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"])
+
+c2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+sbert_embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en") \
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)
+
+ncit_resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_ncit", "en", "clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+])
+
+data = spark.createDataFrame([["The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val oncology_ner = MedicalNerModel.pretrained("ner_oncology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setBlackList(Array("Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                         "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"))
+
+val c2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val sbert_embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("embeddings")
+    .setCaseSensitive(false)
+
+val ncit_resolver = SentenceEntityResolverModel.pretrained("biolordresolve_ncit", "en", "clinical/models")
+    .setInputCols(Array("embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+))
+
+val data = Seq("The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk        | entity         | ncit_code   | resolution_text                       | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:-----------------|:---------------|:------------|:--------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| breast carcinoma | Cancer_Dx      | C4872       | mammary carcinoma [mammary carcinoma] | C4872:::C5214:::C2918:::C9335:::C118809:::C5164:::C206118:::C9245:::C3862:::C403... | 0.3398:::0.3783:::0.3810:::0.4347:::0.4584:::0.4596:::0.4822:::0.4902:::0.4992::... | 0.0577:::0.0716:::0.0726:::0.0945:::0.1051:::0.1056:::0.1163:::0.1202:::0.1246::... | mammary carcinoma [mammary carcinoma]:::breast adenocarcinoma [breast adenocarci... |
+| biopsy           | Pathology_Test | C15189      | biopsy [biopsy]                       | C15189:::C18202:::C15385:::C217124:::C164175:::C182265:::C137813:::C15680:::C153... | 0.3457:::0.4810:::0.4839:::0.5454:::0.5462:::0.5739:::0.5795:::0.5939:::0.6055::... | 0.0598:::0.1157:::0.1171:::0.1487:::0.1492:::0.1647:::0.1679:::0.1764:::0.1833::... | biopsy [biopsy]:::biopsy specimen [biopsy specimen]:::surgical biopsy [surgical ... |
+| chemotherapy     | Chemotherapy   | C15632      | chemotherapy [chemotherapy]           | C15632:::C171212:::C174557:::C71593:::C182408:::C15681:::C168837:::C15756:::C642... | 0.3501:::0.5622:::0.5633:::0.5960:::0.6074:::0.6267:::0.6324:::0.6360:::0.6418::... | 0.0613:::0.1580:::0.1586:::0.1776:::0.1845:::0.1964:::0.2000:::0.2023:::0.2059::... | chemotherapy [chemotherapy]:::chemotherapy session for neoplasm [chemotherapy se... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_ncit|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|1.7 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-04-ncit_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-04-ncit_mapper_en.md
@@ -1,0 +1,192 @@
+---
+layout: model
+title: Mapping Entities with Corresponding NCIt Codes
+author: John Snow Labs
+name: ncit_mapper
+date: 2026-08-04
+tags: [en, chunk_mapper, licensed, clinical, ncit]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps oncology/clinical entities extracted from clinical text to their corresponding NCIt (NCI Thesaurus) codes. It uses ner_oncology for entity recognition and provides fast code mapping without requiring embeddings at inference time. Trained on the NCI Thesaurus dataset (July 28, 2026 release).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/ncit_mapper_en_6.4.1_3.4_1785880587364.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/ncit_mapper_en_6.4.1_3.4_1785880587364.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+ner_oncology = MedicalNerModel.pretrained("ner_oncology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setBlackList(["Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                    "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"])
+
+ncit_mapper = ChunkMapperModel.pretrained("ncit_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["ncit_code"])
+
+pipeline = Pipeline(stages=[
+    document_assembler, sentence_detector, tokenizer, word_embeddings,
+    ner_oncology, ner_converter, ncit_mapper
+])
+data = spark.createDataFrame([["The patient underwent a biopsy that confirmed carcinoma. Imaging revealed lung cancer, and the patient was later diagnosed with breast carcinoma, prompting a mastectomy followed by chemotherapy and radiation therapy. A separate evaluation confirmed melanoma, while ongoing monitoring raised concern for leukemia. A follow-up colonoscopy was also scheduled."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+ner_oncology = medical.NerModel.pretrained("ner_oncology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setBlackList(["Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                    "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"])
+
+ncit_mapper = medical.ChunkMapperModel.pretrained("ncit_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["ncit_code"])
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentence_detector, tokenizer, word_embeddings,
+    ner_oncology, ner_converter, ncit_mapper
+])
+data = spark.createDataFrame([["The patient underwent a biopsy that confirmed carcinoma. Imaging revealed lung cancer, and the patient was later diagnosed with breast carcinoma, prompting a mastectomy followed by chemotherapy and radiation therapy. A separate evaluation confirmed melanoma, while ongoing monitoring raised concern for leukemia. A follow-up colonoscopy was also scheduled."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val wordEmbeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val nerOncology = MedicalNerModel.pretrained("ner_oncology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val nerConverter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setBlackList(Array("Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                         "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"))
+
+val ncitMapper = ChunkMapperModel.pretrained("ncit_mapper", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("ncit_code"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, wordEmbeddings,
+    nerOncology, nerConverter, ncitMapper
+))
+
+val data = Seq("The patient underwent a biopsy that confirmed carcinoma. Imaging revealed lung cancer, and the patient was later diagnosed with breast carcinoma, prompting a mastectomy followed by chemotherapy and radiation therapy. A separate evaluation confirmed melanoma, while ongoing monitoring raised concern for leukemia. A follow-up colonoscopy was also scheduled.").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk         | ncit_code   |
+|:------------------|:------------|
+| biopsy            | C15189      |
+| carcinoma         | C2916       |
+| lung cancer       | C4878       |
+| breast carcinoma  | C4872       |
+| mastectomy        | C15277      |
+| chemotherapy      | C15632      |
+| radiation therapy | C15313      |
+| melanoma          | C3224       |
+| leukemia          | C3161       |
+| colonoscopy       | C16450      |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|ncit_mapper|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|14.9 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-04-ncit_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-04-ncit_mapper_en.md
@@ -32,6 +32,7 @@ This model maps oncology/clinical entities extracted from clinical text to their
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-08-04-sbiobertresolve_ncit_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-04-sbiobertresolve_ncit_en.md
@@ -1,0 +1,215 @@
+---
+layout: model
+title: Sentence Entity Resolver for NCI-t (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_ncit
+date: 2026-08-04
+tags: [en, entity_resolution, licensed, clinical, ncit, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/oncology entities to NCIt (NCI Thesaurus) codes using `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings. Trained on the NCI Thesaurus dataset (July 28, 2026 release).
+
+{:.btn-box}
+[Live Demo](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_ncit_en_6.4.1_3.4_1785878391478.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_ncit_en_6.4.1_3.4_1785878391478.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+oncology_ner = MedicalNerModel.pretrained("ner_oncology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setBlackList(["Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                    "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"])
+
+c2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+sbert_embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models") \
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+ncit_resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_ncit", "en", "clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+])
+
+data = spark.createDataFrame([["The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")\
+    .setInputCols(["sentence", "token"])\
+    .setOutputCol("word_embeddings")
+
+oncology_ner = medical.NerModel.pretrained("ner_oncology", "en", "clinical/models")\
+    .setInputCols(["sentence", "token", "word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence", "token", "ner"])\
+    .setOutputCol("ner_chunk")\
+    .setBlackList(["Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                    "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"])
+
+c2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+sbert_embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models") \
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+ncit_resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_ncit", "en", "clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+])
+
+data = spark.createDataFrame([["The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy."]]).toDF("text")
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val oncology_ner = MedicalNerModel.pretrained("ner_oncology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setBlackList(Array("Age", "Date", "Death_Entity", "Gender", "Race_Ethnicity",
+                         "Relative_Date", "Smoking_Status", "Dosage", "Tumor_Size"))
+
+val c2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val sbert_embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val ncit_resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_ncit", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolver_pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    oncology_ner, ner_converter, c2doc, sbert_embedder, ncit_resolver
+))
+
+val data = Seq("The patient was diagnosed with breast carcinoma and underwent a biopsy followed by chemotherapy.").toDF("text")
+val result = resolver_pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk        | entity         | ncit_code   | resolution_text                     | all_k_results                                                                       | all_k_distances                                                                     | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:-----------------|:---------------|:------------|:------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| breast carcinoma | Cancer_Dx      | C4872       | breast carcinoma [breast carcinoma] | C4872:::C4017:::C147915:::C217270:::C53554:::C118809:::C40364:::C5214:::C167189:... | 0.0000:::4.5876:::4.7017:::4.8119:::5.0894:::5.0900:::5.1965:::5.2565:::5.3467::... | 0.0000:::0.0320:::0.0341:::0.0360:::0.0400:::0.0399:::0.0416:::0.0425:::0.0441::... | breast carcinoma [breast carcinoma]:::breast ductal carcinoma [breast ductal car... |
+| biopsy           | Pathology_Test | C15189      | biopsy [biopsy]                     | C15189:::C192621:::C18202:::C77677:::C164175:::C160869:::C49567:::C15190:::C1608... | 0.0000:::4.5896:::4.6661:::5.1726:::5.6365:::5.9746:::6.5265:::7.0238:::7.2550::... | 0.0000:::0.0336:::0.0353:::0.0433:::0.0513:::0.0583:::0.0682:::0.0803:::0.0854::... | biopsy [biopsy]:::biopsy finding [biopsy finding]:::biopsy specimen [biopsy spec... |
+| chemotherapy     | Chemotherapy   | C15632      | chemotherapy [chemotherapy]         | C15632:::C160336:::C204795:::C168835:::C274:::C15681:::C191:::C158802:::C58008::... | 0.0000:::4.8505:::5.9540:::6.1603:::6.3463:::6.4772:::6.6041:::7.2356:::7.2422::... | 0.0000:::0.0374:::0.0595:::0.0640:::0.0664:::0.0694:::0.0735:::0.0844:::0.0858::... | chemotherapy [chemotherapy]:::chemotherapy received [chemotherapy received]:::ch... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_ncit|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|1.7 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-04-sbiobertresolve_ncit_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-04-sbiobertresolve_ncit_en.md
@@ -32,6 +32,7 @@ This model maps clinical/oncology entities to NCIt (NCI Thesaurus) codes using `
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\


### PR DESCRIPTION
# ATC 20260425 — Resolvers & Mapper

Adds 3 sentence entity resolvers and 1 chunk mapper for the Anatomical Therapeutic Chemical (ATC) classification, release 2026-04-25, to JSL Models Hub.

## Resolvers
| Model | Embedding | Status |
|---|---|---|
| `sbiobertresolve_atc` | `sbiobert_base_cased_mli_onnx` | Updated |
| `biolordresolve_atc` | `mpnet_embeddings_biolord_2023_c` | New |
| `bgeresolve_atc` | `bge_base_en_v1_5_onnx` | New |

## Mappers
| Model | Direction | Status |
|---|---|---|
| `atc_mapper` | free text → ATC code | New |
