### PR TITLE
2026-08-06-sbiobertresolve_hcpcs_en

### DIFF
--- a/docs/_posts/ozgurcaglayan1981/2026-08-06-bgeresolve_hcpcs_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-06-bgeresolve_hcpcs_en.md
@@ -32,6 +32,7 @@ This model maps entities to HCPCS (Healthcare Common Procedure Coding System) co
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-08-06-bgeresolve_hcpcs_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-06-bgeresolve_hcpcs_en.md
@@ -1,0 +1,141 @@
+---
+layout: model
+title: Sentence Entity Resolver for HCPCS Codes (BGEEmbeddings)
+author: John Snow Labs
+name: bgeresolve_hcpcs
+date: 2026-08-06
+tags: [en, entity_resolution, licensed, clinical, hcpcs, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps entities to HCPCS (Healthcare Common Procedure Coding System) codes using `bge_base_en_v1_5_onnx` Sentence Embeddings. Trained on the current CMS HCPCS Level II Alpha-Numeric master file (release 20260701), with an aux label (`domain_id` — the OMOP CDM domain, e.g. Device/Drug/Procedure/Observation/Measurement) returned alongside the resolved code.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hcpcs_en_6.4.1_3.4_1785977923935.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hcpcs_en_6.4.1_3.4_1785977923935.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("ner_chunk")
+
+sbert_embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+hcpcs_resolver = SentenceEntityResolverModel.pretrained("bgeresolve_hcpcs", "en", "clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("hcpcs_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sbert_embedder, hcpcs_resolver
+])
+
+# 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+# independently, demonstrates the domain_id aux label across all 4 categories at once.
+data = spark.createDataFrame([[t] for t in ['Unilateral breast prosthesis mastectomy bra with integrated form', 'Injection, brentuximab vedotin, 1 mg', 'Spirometry results showing fev1/fvc below 70%', 'Alcohol and/or drug screening']], ["text"])
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("ner_chunk")
+
+sbert_embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+hcpcs_resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_hcpcs", "en", "clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("hcpcs_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sbert_embedder, hcpcs_resolver
+])
+
+# 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+# independently, demonstrates the domain_id aux label across all 4 categories at once.
+data = spark.createDataFrame([[t] for t in ['Unilateral breast prosthesis mastectomy bra with integrated form', 'Injection, brentuximab vedotin, 1 mg', 'Spirometry results showing fev1/fvc below 70%', 'Alcohol and/or drug screening']], ["text"])
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("ner_chunk")
+
+val sbertEmbedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("sentence_embeddings")
+    .setCaseSensitive(false)
+
+val hcpcsResolver = SentenceEntityResolverModel.pretrained("bgeresolve_hcpcs", "en", "clinical/models")
+    .setInputCols(Array("sentence_embeddings"))
+    .setOutputCol("hcpcs_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolverPipeline = new Pipeline().setStages(Array(
+    documentAssembler, sbertEmbedder, hcpcsResolver
+))
+
+// 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+// independently, demonstrates the domain_id aux label across all 4 categories at once.
+val data = Seq("Unilateral breast prosthesis mastectomy bra with integrated form", "Injection, brentuximab vedotin, 1 mg", "Spirometry results showing fev1/fvc below 70%", "Alcohol and/or drug screening").toDF("text")
+val result = resolverPipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                                                        | hcpcs_code   | resolution                                                                                                | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:-----------------------------------------------------------------|:-------------|:----------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| Unilateral breast prosthesis mastectomy bra with integrated form | L8001        | Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unilateral, any size, any type | L8001:::L8002:::L8015:::L8000:::L8020:::L8035:::L8031:::L8039:::L8030:::C1789:::... | 0.0886:::0.1215:::0.1467:::0.1474:::0.1515:::0.1778:::0.1902:::0.1943:::0.1943::... | Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unila... | Device:::Device:::Device:::Device:::Device:::Device:::Device:::Device:::Device::... |
+| Injection, brentuximab vedotin, 1 mg                             | J9042        | Injection, brentuximab vedotin, 1 mg                                                                      | J9042:::J9273:::J9326:::J9309:::J3380:::J9271:::J0517:::J2182:::J9295:::J2329:::... | 0.0000:::0.1009:::0.1073:::0.1094:::0.1229:::0.1229:::0.1343:::0.1353:::0.1364::... | Injection, brentuximab vedotin, 1 mg:::Injection, tisotumab vedotin-tftv, 1 mg::... | Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Dru... |
+| Spirometry results showing fev1/fvc below 70%                    | G8924        | Spirometry results documented (fev1/fvc < 70%)                                                            | G8924:::M1213:::M1214:::M1216:::M1218:::M1460:::M1326:::M1215:::S5180:::G9605:::... | 0.0780:::0.1255:::0.1399:::0.1547:::0.3301:::0.3373:::0.3527:::0.3530:::0.3553::... | Spirometry results documented (fev1/fvc < 70%):::No history of spirometry result... | Observation:::Observation:::Observation:::Observation:::Observation:::Observatio... |
+| Alcohol and/or drug screening                                    | H0049        | Alcohol and/or drug screening                                                                             | H0049:::H0001:::H0003:::G0442:::G2197:::H0048:::G2196:::H0006:::H0014:::G9622:::... | 0.0000:::0.0858:::0.1236:::0.2411:::0.2428:::0.2486:::0.2496:::0.2501:::0.2522::... | Alcohol and/or drug screening:::Alcohol and/or drug assessment:::Alcohol and/or ... | Measurement:::Procedure:::Measurement:::Procedure:::Observation:::Measurement:::... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_hcpcs|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[hcpcs_code]|
+|Language:|en|
+|Size:|21.3 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-06-biolordresolve_hcpcs_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-06-biolordresolve_hcpcs_en.md
@@ -32,6 +32,7 @@ This model maps entities to HCPCS (Healthcare Common Procedure Coding System) co
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-08-06-biolordresolve_hcpcs_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-06-biolordresolve_hcpcs_en.md
@@ -1,0 +1,141 @@
+---
+layout: model
+title: Sentence Entity Resolver for HCPCS Codes (MPNetEmbeddings)
+author: John Snow Labs
+name: biolordresolve_hcpcs
+date: 2026-08-06
+tags: [en, entity_resolution, licensed, clinical, hcpcs, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps entities to HCPCS (Healthcare Common Procedure Coding System) codes using `mpnet_embeddings_biolord_2023_c` Sentence Embeddings. Trained on the current CMS HCPCS Level II Alpha-Numeric master file (release 20260701), with an aux label (`domain_id` — the OMOP CDM domain, e.g. Device/Drug/Procedure/Observation/Measurement) returned alongside the resolved code.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_hcpcs_en_6.4.1_3.4_1785977477412.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_hcpcs_en_6.4.1_3.4_1785977477412.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("ner_chunk")
+
+sbert_embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+hcpcs_resolver = SentenceEntityResolverModel.pretrained("biolordresolve_hcpcs", "en", "clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("hcpcs_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sbert_embedder, hcpcs_resolver
+])
+
+# 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+# independently, demonstrates the domain_id aux label across all 4 categories at once.
+data = spark.createDataFrame([[t] for t in ['Unilateral breast prosthesis mastectomy bra with integrated form', 'Injection, brentuximab vedotin, 1 mg', 'Documented spirometry results with fev1/fvc under 70%', 'Alcohol and/or drug screening']], ["text"])
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("ner_chunk")
+
+sbert_embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+hcpcs_resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_hcpcs", "en", "clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("hcpcs_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sbert_embedder, hcpcs_resolver
+])
+
+# 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+# independently, demonstrates the domain_id aux label across all 4 categories at once.
+data = spark.createDataFrame([[t] for t in ['Unilateral breast prosthesis mastectomy bra with integrated form', 'Injection, brentuximab vedotin, 1 mg', 'Documented spirometry results with fev1/fvc under 70%', 'Alcohol and/or drug screening']], ["text"])
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("ner_chunk")
+
+val sbertEmbedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("sentence_embeddings")
+    .setCaseSensitive(false)
+
+val hcpcsResolver = SentenceEntityResolverModel.pretrained("biolordresolve_hcpcs", "en", "clinical/models")
+    .setInputCols(Array("sentence_embeddings"))
+    .setOutputCol("hcpcs_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolverPipeline = new Pipeline().setStages(Array(
+    documentAssembler, sbertEmbedder, hcpcsResolver
+))
+
+// 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+// independently, demonstrates the domain_id aux label across all 4 categories at once.
+val data = Seq("Unilateral breast prosthesis mastectomy bra with integrated form", "Injection, brentuximab vedotin, 1 mg", "Documented spirometry results with fev1/fvc under 70%", "Alcohol and/or drug screening").toDF("text")
+val result = resolverPipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                                                        | hcpcs_code   | resolution                                                                                                | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:-----------------------------------------------------------------|:-------------|:----------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| Unilateral breast prosthesis mastectomy bra with integrated form | L8001        | Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unilateral, any size, any type | L8001:::L8000:::L8002:::L8020:::L8030:::L8035:::L8015:::L8600:::L8031:::M1280:::... | 0.0865:::0.1999:::0.2090:::0.2731:::0.3186:::0.3261:::0.3317:::0.3598:::0.3927::... | Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unila... | Device:::Device:::Device:::Device:::Device:::Device:::Device:::Device:::Device::... |
+| Injection, brentuximab vedotin, 1 mg                             | J9042        | Injection, brentuximab vedotin, 1 mg                                                                      | J9042:::J9326:::J9273:::J9309:::J9039:::J9229:::J0202:::J9176:::J9055:::J9053:::... | 0.0000:::0.2016:::0.2323:::0.2607:::0.2660:::0.2697:::0.2733:::0.2814:::0.2821::... | Injection, brentuximab vedotin, 1 mg:::Injection, telisotuzumab vedotin-tllv, 1 ... | Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::null:::Drug:::Dru... |
+| Documented spirometry results with fev1/fvc under 70%            | G8924        | Spirometry results documented (fev1/fvc < 70%)                                                            | G8924:::M1214:::M1216:::M1213:::M1217:::A4614:::M1215:::S8110:::G9432:::G8396:::... | 0.1389:::0.2215:::0.2241:::0.2371:::0.5209:::0.5521:::0.5537:::0.6012:::0.6106::... | Spirometry results documented (fev1/fvc < 70%):::Spirometry results with confirm... | Observation:::Observation:::Observation:::Observation:::Observation:::Device:::O... |
+| Alcohol and/or drug screening                                    | H0049        | Alcohol and/or drug screening                                                                             | H0049:::H0001:::H0003:::H0048:::G0442:::G2196:::G2197:::H0002:::H0028:::G9622:::... | 0.0000:::0.1424:::0.1469:::0.2789:::0.3269:::0.3507:::0.3563:::0.3941:::0.3985::... | Alcohol and/or drug screening:::Alcohol and/or drug assessment:::Alcohol and/or ... | Measurement:::Procedure:::Measurement:::Measurement:::Procedure:::Observation:::... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_hcpcs|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[hcpcs_code]|
+|Language:|en|
+|Size:|21.3 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-06-hcpcs_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-06-hcpcs_mapper_en.md
@@ -32,6 +32,7 @@ This model maps entities extracted from text to their corresponding HCPCS (Healt
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\

--- a/docs/_posts/ozgurcaglayan1981/2026-08-06-hcpcs_mapper_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-06-hcpcs_mapper_en.md
@@ -1,0 +1,137 @@
+---
+layout: model
+title: Mapping HCPCS Codes with Their Corresponding Entities
+author: John Snow Labs
+name: hcpcs_mapper
+date: 2026-08-06
+tags: [en, chunk_mapper, licensed, clinical, hcpcs]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps entities extracted from text to their corresponding HCPCS (Healthcare Common Procedure Coding System) codes. It performs a direct lookup against the full training text , providing fast, exact-match code mapping without requiring embeddings at inference time. Trained on the current CMS HCPCS Level II Alpha-Numeric master file (release 20260701).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hcpcs_mapper_en_6.4.1_3.4_1786006372539.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hcpcs_mapper_en_6.4.1_3.4_1786006372539.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+hcpcs_mapper = ChunkMapperModel.pretrained("hcpcs_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hcpcs_code"])
+
+pipeline = Pipeline(stages=[
+    document_assembler, doc2chunk, hcpcs_mapper
+])
+
+# 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row looked up
+# independently against the dictionary.
+data = spark.createDataFrame([[t] for t in ['Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unilateral, any size, any type', 'Injection, brentuximab vedotin, 1 mg', 'Spirometry results documented (fev1/fvc < 70%)', 'Alcohol and/or drug screening']], ["text"])
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+hcpcs_mapper = medical.ChunkMapperModel.pretrained("hcpcs_mapper", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hcpcs_code"])
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler, doc2chunk, hcpcs_mapper
+])
+
+# 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row looked up
+# independently against the dictionary.
+data = spark.createDataFrame([[t] for t in ['Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unilateral, any size, any type', 'Injection, brentuximab vedotin, 1 mg', 'Spirometry results documented (fev1/fvc < 70%)', 'Alcohol and/or drug screening']], ["text"])
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val doc2Chunk = new Doc2Chunk()
+    .setInputCols(Array("document"))
+    .setOutputCol("ner_chunk")
+
+val hcpcsMapper = ChunkMapperModel.pretrained("hcpcs_mapper", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("hcpcs_code"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, doc2Chunk, hcpcsMapper
+))
+
+// 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row looked up
+// independently against the dictionary.
+val data = Seq("Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unilateral, any size, any type", "Injection, brentuximab vedotin, 1 mg", "Spirometry results documented (fev1/fvc < 70%)", "Alcohol and/or drug screening").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                                                                                                 | hcpcs_code   |
+|:----------------------------------------------------------------------------------------------------------|:-------------|
+| Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unilateral, any size, any type | L8001        |
+| Injection, brentuximab vedotin, 1 mg                                                                      | J9042        |
+| Spirometry results documented (fev1/fvc < 70%)                                                            | G8924        |
+| Alcohol and/or drug screening                                                                             | H0049        |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hcpcs_mapper|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|313.2 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-06-sbiobertresolve_hcpcs_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-06-sbiobertresolve_hcpcs_en.md
@@ -1,0 +1,141 @@
+---
+layout: model
+title: Sentence Entity Resolver for HCPCS Codes
+author: John Snow Labs
+name: sbiobertresolve_hcpcs
+date: 2026-08-06
+tags: [en, entity_resolution, licensed, clinical, hcpcs, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps entities to HCPCS (Healthcare Common Procedure Coding System) codes using `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings. Trained on the current CMS HCPCS Level II Alpha-Numeric master file (release 20260701). This update adds an aux label (`domain_id` — the OMOP CDM domain, e.g. Device/Drug/Procedure/Observation/Measurement) alongside the resolved code, which the previous version of this model did not return.
+
+{:.btn-box}
+[Live Demo](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_hcpcs_en_6.4.1_3.4_1785976182645.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_hcpcs_en_6.4.1_3.4_1785976182645.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("ner_chunk")
+
+sbert_embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+hcpcs_resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_hcpcs", "en", "clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("hcpcs_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = Pipeline(stages=[
+    document_assembler, sbert_embedder, hcpcs_resolver
+])
+
+# 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+# independently, demonstrates the domain_id aux label across all 4 categories at once.
+data = spark.createDataFrame([[t] for t in ['Unilateral breast prosthesis mastectomy bra with integrated form', 'Injection, brentuximab vedotin, 1 mg', 'Spirometry results showing fev1/fvc below 70%', 'Alcohol and/or drug screening']], ["text"])
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("ner_chunk")
+
+sbert_embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("sentence_embeddings")\
+    .setCaseSensitive(False)
+
+hcpcs_resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_hcpcs", "en", "clinical/models")\
+    .setInputCols(["sentence_embeddings"])\
+    .setOutputCol("hcpcs_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+resolver_pipeline = nlp.Pipeline(stages=[
+    document_assembler, sbert_embedder, hcpcs_resolver
+])
+
+# 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+# independently, demonstrates the domain_id aux label across all 4 categories at once.
+data = spark.createDataFrame([[t] for t in ['Unilateral breast prosthesis mastectomy bra with integrated form', 'Injection, brentuximab vedotin, 1 mg', 'Spirometry results showing fev1/fvc below 70%', 'Alcohol and/or drug screening']], ["text"])
+result = resolver_pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("ner_chunk")
+
+val sbertEmbedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("sentence_embeddings")
+    .setCaseSensitive(false)
+
+val hcpcsResolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_hcpcs", "en", "clinical/models")
+    .setInputCols(Array("sentence_embeddings"))
+    .setOutputCol("hcpcs_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val resolverPipeline = new Pipeline().setStages(Array(
+    documentAssembler, sbertEmbedder, hcpcsResolver
+))
+
+// 4 domain terms in one DataFrame (Device/Drug/Observation/Measurement) -- each row resolved
+// independently, demonstrates the domain_id aux label across all 4 categories at once.
+val data = Seq("Unilateral breast prosthesis mastectomy bra with integrated form", "Injection, brentuximab vedotin, 1 mg", "Spirometry results showing fev1/fvc below 70%", "Alcohol and/or drug screening").toDF("text")
+val result = resolverPipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk                                                        | hcpcs_code   | resolution                                                                                                | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:-----------------------------------------------------------------|:-------------|:----------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| Unilateral breast prosthesis mastectomy bra with integrated form | L8001        | Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unilateral, any size, any type | L8001:::L8020:::L8015:::S2066:::S2067:::S2068:::L8035:::L8002:::G9704:::L8031:::... | 0.1237:::0.1296:::0.1594:::0.1629:::0.1837:::0.1913:::0.2018:::0.2127:::0.2162::... | Breast prosthesis, mastectomy bra, with integrated breast prosthesis form, unila... | Device:::Device:::Device:::Procedure:::Procedure:::Procedure:::Device:::Device::... |
+| Injection, brentuximab vedotin, 1 mg                             | J9042        | Injection, brentuximab vedotin, 1 mg                                                                      | J9042:::J9326:::J0179:::J1823:::J0584:::J9273:::J2327:::Q9997:::J9347:::J9350:::... | 0.0000:::0.0502:::0.0497:::0.0504:::0.0555:::0.0612:::0.0599:::0.0619:::0.0617::... | Injection, brentuximab vedotin, 1 mg:::Injection, telisotuzumab vedotin-tllv, 1 ... | Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::Drug:::null:::Drug:::Dru... |
+| Spirometry results showing fev1/fvc below 70%                    | G8924        | Spirometry results documented (fev1/fvc < 70%)                                                            | G8924:::M1214:::A7006:::M1213:::G8395:::M1371:::G8694:::A4306:::G9243:::G8934:::... | 0.0521:::0.1662:::0.3001:::0.2925:::0.3165:::0.3009:::0.3166:::0.3170:::0.3217::... | Spirometry results documented (fev1/fvc < 70%):::Spirometry results with confirm... | Observation:::Observation:::Device:::Observation:::Observation:::Observation:::O... |
+| Alcohol and/or drug screening                                    | H0049        | Alcohol and/or drug screening                                                                             | H0049:::H0001:::H0006:::H0003:::H0022:::T1007:::T1012:::H0014:::H0020:::H0005:::... | 0.0000:::0.0354:::0.0829:::0.0930:::0.1171:::0.1172:::0.1228:::0.1318:::0.1711::... | Alcohol and/or drug screening:::Alcohol and/or drug assessment:::Alcohol and/or ... | Measurement:::Procedure:::Procedure:::Measurement:::Procedure:::Observation:::Ob... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_hcpcs|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sentence_embeddings]|
+|Output Labels:|[hcpcs_code]|
+|Language:|en|
+|Size:|21.3 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-06-sbiobertresolve_hcpcs_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-06-sbiobertresolve_hcpcs_en.md
@@ -32,6 +32,7 @@ This model maps entities to HCPCS (Healthcare Common Procedure Coding System) co
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
+  
 ```python
 
 document_assembler = DocumentAssembler()\


### PR DESCRIPTION
## HCPCS 20260701 — Resolver & Mapper Update

Adds/updates 3 resolvers and 1 new mapper for HCPCS (Healthcare Common Procedure Coding System), release 2026-07 (7,417 codes, full CMS HCPCS Level II coverage).

### Models

| Model | Type | Embedding | Status |
|---|---|---|---|
| `sbiobertresolve_hcpcs` | Sentence Entity Resolver | `sbiobert_base_cased_mli_onnx` | Updated — restores `domain_id` aux label (Device/Drug/Procedure/Observation/Measurement), previously dropped in the 2022 version |
| `biolordresolve_hcpcs` | Sentence Entity Resolver | `mpnet_embeddings_biolord_2023_c` | New |
| `bgeresolve_hcpcs` | Sentence Entity Resolver | `bge_base_en_v1_5_onnx` | New |
| `hcpcs_mapper` | Chunk Mapper | — | New — `concept_name → hcpcs_code` direct lookup, 7,245 dictionary entries |

### Data

Trained on the current CMS HCPCS Level II Alpha-Numeric master file (release 2026-07).

### Distribution

All 4 models live on JSL Models Hub.
