### PR TITLE
2026-08-07-sbiobertresolve_hgnc_2026_en

### DIFF
--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-bgeresolve_hgnc_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-bgeresolve_hgnc_2026_en.md
@@ -1,0 +1,212 @@
+---
+layout: model
+title: Sentence Entity Resolver for HGNC Gene Symbols (BGE (bge_base_en_v1_5_onnx) Embeddings)
+author: John Snow Labs
+name: bgeresolve_hgnc_2026
+date: 2026-08-07
+tags: [en, entity_resolution, licensed, clinical, hgnc, gene, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene symbols and official names to HUGO Gene Nomenclature Committee (HGNC) identifiers using `bge_base_en_v1_5_onnx` embeddings. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hgnc_2026_en_6.4.1_3.4_1786107676486.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hgnc_2026_en_6.4.1_3.4_1786107676486.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_hgnc_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_hgnc_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("GENE"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_hgnc_2026", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk   | entity   | HGNC Code   | Resolution                              | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:------------|:---------|:------------|:----------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| BRCA1       | GENE     | HGNC:1100   | BRCA1 [BRCA1 DNA repair associated]     | HGNC:1100:::HGNC:28470:::HGNC:58363:::HGNC:950:::HGNC:25008:::HGNC:952:::HGNC:10... | 0.0000:::0.0776:::0.1256:::0.1898:::0.1937:::0.2021:::0.2026:::0.2085:::0.2163::... | BRCA1 [BRCA1 DNA repair associated]:::BRCA1P1 [BRCA1 pseudogene 1]:::BRCA1-OT1 [... | protein-coding gene :: gene with protein product:::pseudogene :: pseudogene:::no... |
+| EGFR        | GENE     | HGNC:3236   | EGFR [epidermal growth factor receptor] | HGNC:3236:::HGNC:3229:::HGNC:40207:::HGNC:9600:::HGNC:49511:::HGNC:3420:::HGNC:8... | 0.0000:::0.1528:::0.1778:::0.2075:::0.2304:::0.2435:::0.2572:::0.2609:::0.2622::... | EGFR [epidermal growth factor receptor]:::EGF [epidermal growth factor]:::EGFR-A... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| KRAS        | GENE     | HGNC:6407   | KRAS [KRas proto-oncogene, GTPase]      | HGNC:6407:::HGNC:52478:::HGNC:10447:::HGNC:17271:::HGNC:6406:::HGNC:5174:::HGNC:... | 0.0000:::0.2407:::0.2640:::0.2939:::0.2941:::0.3015:::0.3102:::0.3116:::0.3197::... | KRAS [KRas proto-oncogene, GTPase]:::NTRAS [non-coding transcript regulating alt... | protein-coding gene :: gene with protein product:::non-coding RNA :: RNA, long n... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_hgnc_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|260.7 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-bgeresolve_hgnc_augmented_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-bgeresolve_hgnc_augmented_2026_en.md
@@ -1,0 +1,212 @@
+---
+layout: model
+title: Sentence Entity Resolver for HGNC Gene Symbols - Augmented (BGE (bge_base_en_v1_5_onnx) Embeddings)
+author: John Snow Labs
+name: bgeresolve_hgnc_augmented_2026
+date: 2026-08-07
+tags: [en, entity_resolution, licensed, clinical, hgnc, gene, bge, augmented]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene symbols, official names, and their known alias/previous symbols and names to HUGO Gene Nomenclature Committee (HGNC) identifiers using `bge_base_en_v1_5_onnx` embeddings. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786109830398.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786109830398.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_hgnc_augmented_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_hgnc_augmented_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("GENE"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_hgnc_augmented_2026", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk   | entity   | HGNC Code   | Resolution                              | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:------------|:---------|:------------|:----------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| BRCA1       | GENE     | HGNC:1100   | BRCA1 [BRCA1 DNA repair associated]     | HGNC:1100:::HGNC:28470:::HGNC:950:::HGNC:58363:::HGNC:20473:::HGNC:25008:::HGNC:... | 0.0000:::0.0776:::0.1254:::0.1256:::0.1322:::0.1937:::0.1971:::0.1986:::0.2021::... | BRCA1 [BRCA1 DNA repair associated]:::BRCA1P1 [BRCA1 pseudogene 1]:::BRCA1 assoc... | protein-coding gene :: gene with protein product:::pseudogene :: pseudogene:::pr... |
+| EGFR        | GENE     | HGNC:3236   | EGFR [epidermal growth factor receptor] | HGNC:3236:::HGNC:20561:::HGNC:54482:::HGNC:7029:::HGNC:3229:::HGNC:5465:::HGNC:4... | 0.0000:::0.0938:::0.1377:::0.1402:::0.1528:::0.1632:::0.1778:::0.1923:::0.2075::... | EGFR [epidermal growth factor receptor]:::EGFR-RS [rhomboid 5 homolog 1]:::Lnc-E... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| KRAS        | GENE     | HGNC:6407   | KRAS [KRas proto-oncogene, GTPase]      | HGNC:6407:::HGNC:6406:::HGNC:17898:::HGNC:10447:::HGNC:7989:::HGNC:25121:::HGNC:... | 0.0000:::0.2075:::0.2275:::0.2300:::0.2397:::0.2404:::0.2407:::0.2457:::0.2547::... | KRAS [KRas proto-oncogene, GTPase]:::KRAS1P [KRas proto-oncogene, GTPase pseudog... | protein-coding gene :: gene with protein product:::pseudogene :: pseudogene:::pr... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_hgnc_augmented_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|566.3 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-bgeresolve_hgnc_augmented_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-bgeresolve_hgnc_augmented_2026_en.md
@@ -23,8 +23,8 @@ This model maps gene symbols, official names, and their known alias/previous sym
 {:.btn-box}
 [Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
 [Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
-[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786109830398.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
-[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786109830398.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786110230304.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786110230304.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
 
 ## How to use
 

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-biolordresolve_hgnc_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-biolordresolve_hgnc_2026_en.md
@@ -1,0 +1,215 @@
+---
+layout: model
+title: Sentence Entity Resolver for HGNC Gene Symbols (BioLORD (mpnet_embeddings_biolord_2023_c) Embeddings)
+author: John Snow Labs
+name: biolordresolve_hgnc_2026
+date: 2026-08-07
+tags: [en, entity_resolution, licensed, clinical, hgnc, gene, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene symbols and official names to HUGO Gene Nomenclature Committee (HGNC) identifiers using `mpnet_embeddings_biolord_2023_c` embeddings. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_hgnc_2026_en_6.4.1_3.4_1786107013832.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_hgnc_2026_en_6.4.1_3.4_1786107013832.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_hgnc_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_hgnc_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("GENE"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("embeddings")
+    .setCaseSensitive(false)
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_hgnc_2026", "en", "clinical/models")
+    .setInputCols(Array("embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk   | entity   | HGNC Code   | Resolution                              | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:------------|:---------|:------------|:----------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| BRCA1       | GENE     | HGNC:1100   | BRCA1 [BRCA1 DNA repair associated]     | HGNC:1100:::HGNC:1101:::HGNC:28470:::HGNC:58363:::HGNC:25008:::HGNC:1099:::HGNC:... | 0.0000:::0.0690:::0.0980:::0.1656:::0.1882:::0.1962:::0.2005:::0.2085:::0.2125::... | BRCA1 [BRCA1 DNA repair associated]:::BRCA2 [BRCA2 DNA repair associated]:::BRCA... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| EGFR        | GENE     | HGNC:3236   | EGFR [epidermal growth factor receptor] | HGNC:3236:::HGNC:3229:::HGNC:40207:::HGNC:26810:::HGNC:3235:::HGNC:9600:::HGNC:2... | 0.0000:::0.1780:::0.2620:::0.2658:::0.2740:::0.2741:::0.2873:::0.2949:::0.3080::... | EGFR [epidermal growth factor receptor]:::EGF [epidermal growth factor]:::EGFR-A... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| KRAS        | GENE     | HGNC:6407   | KRAS [KRas proto-oncogene, GTPase]      | HGNC:6407:::HGNC:6406:::HGNC:7108:::HGNC:4021:::HGNC:6215:::HGNC:5176:::HGNC:303... | 0.0000:::0.2699:::0.3207:::0.3300:::0.3371:::0.3408:::0.3481:::0.3614:::0.3659::... | KRAS [KRas proto-oncogene, GTPase]:::KRASP1 [KRas proto-oncogene, GTPase pseudog... | protein-coding gene :: gene with protein product:::pseudogene :: pseudogene:::pr... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_hgnc_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|260.8 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-biolordresolve_hgnc_augmented_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-biolordresolve_hgnc_augmented_2026_en.md
@@ -1,0 +1,215 @@
+---
+layout: model
+title: Sentence Entity Resolver for HGNC Gene Symbols - Augmented (BioLORD (mpnet_embeddings_biolord_2023_c) Embeddings)
+author: John Snow Labs
+name: biolordresolve_hgnc_augmented_2026
+date: 2026-08-07
+tags: [en, entity_resolution, licensed, clinical, hgnc, gene, biolord, augmented]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene symbols, official names, and their known alias/previous symbols and names to HUGO Gene Nomenclature Committee (HGNC) identifiers using `mpnet_embeddings_biolord_2023_c` embeddings. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786109270881.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786109270881.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_hgnc_augmented_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_hgnc_augmented_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("GENE"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("embeddings")
+    .setCaseSensitive(false)
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_hgnc_augmented_2026", "en", "clinical/models")
+    .setInputCols(Array("embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk   | entity   | HGNC Code   | Resolution                              | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:------------|:---------|:------------|:----------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| BRCA1       | GENE     | HGNC:1100   | BRCA1 [BRCA1 DNA repair associated]     | HGNC:1100:::HGNC:15550:::HGNC:1101:::HGNC:28470:::HGNC:24324:::HGNC:58363:::HGNC... | 0.0000:::0.0599:::0.0690:::0.0980:::0.1376:::0.1656:::0.1767:::0.1831:::0.1859::... | BRCA1 [BRCA1 DNA repair associated]:::BRCAA1 [AT-rich interaction domain 4B]:::B... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| EGFR        | GENE     | HGNC:3236   | EGFR [epidermal growth factor receptor] | HGNC:3236:::HGNC:20561:::HGNC:3229:::HGNC:13780:::HGNC:54482:::HGNC:3665:::HGNC:... | 0.0000:::0.0956:::0.1780:::0.1925:::0.2010:::0.2355:::0.2438:::0.2489:::0.2594::... | EGFR [epidermal growth factor receptor]:::EGFR-RS [rhomboid 5 homolog 1]:::EGF [... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| KRAS        | GENE     | HGNC:6407   | KRAS [KRas proto-oncogene, GTPase]      | HGNC:6407:::HGNC:6406:::HGNC:17898:::HGNC:17899:::HGNC:4221:::HGNC:28932:::HGNC:... | 0.0000:::0.1855:::0.2429:::0.2629:::0.2645:::0.2857:::0.2925:::0.3058:::0.3062::... | KRAS [KRas proto-oncogene, GTPase]:::KRAS1P [KRas proto-oncogene, GTPase pseudog... | protein-coding gene :: gene with protein product:::pseudogene :: pseudogene:::pr... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_hgnc_augmented_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|566.4 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_code_symbol_mapper_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_code_symbol_mapper_2026_en.md
@@ -1,0 +1,126 @@
+---
+layout: model
+title: Mapping HGNC Codes with Their Corresponding Gene Symbols
+author: John Snow Labs
+name: hgnc_code_symbol_mapper_2026
+date: 2026-08-07
+tags: [en, chunk_mapper, licensed, clinical, hgnc, gene]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps HGNC identifiers to their current approved gene symbol. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hgnc_code_symbol_mapper_2026_en_6.4.1_3.4_1786131551319.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hgnc_code_symbol_mapper_2026_en_6.4.1_3.4_1786131551319.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+code_mapper = ChunkMapperModel.pretrained("hgnc_code_symbol_mapper_2026","en","clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["symbol"])
+
+pipeline = Pipeline(stages=[document_assembler, chunk_assembler, code_mapper])
+
+data = spark.createDataFrame([[c] for c in ['HGNC:11998', 'HGNC:1100', 'HGNC:3236', 'HGNC:6407', 'HGNC:583', 'HGNC:7989', 'HGNC:9588', 'HGNC:12805']]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+code_mapper = medical.ChunkMapperModel.pretrained("hgnc_code_symbol_mapper_2026","en","clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["symbol"])
+
+pipeline = nlp.Pipeline(stages=[document_assembler, chunk_assembler, code_mapper])
+
+data = spark.createDataFrame([[c] for c in ['HGNC:11998', 'HGNC:1100', 'HGNC:3236', 'HGNC:6407', 'HGNC:583', 'HGNC:7989', 'HGNC:9588', 'HGNC:12805']]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val chunkAssembler = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("ner_chunk")
+
+val codeMapper = ChunkMapperModel
+    .pretrained("hgnc_code_symbol_mapper_2026", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("symbol"))
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, chunkAssembler, codeMapper))
+
+val data = Seq("HGNC:11998", "HGNC:1100", "HGNC:3236", "HGNC:6407", "HGNC:583", "HGNC:7989", "HGNC:9588", "HGNC:12805").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| HGNC Code   | symbol   |
+|:------------|:---------|
+| HGNC:11998  | TP53     |
+| HGNC:1100   | BRCA1    |
+| HGNC:3236   | EGFR     |
+| HGNC:6407   | KRAS     |
+| HGNC:583    | APC      |
+| HGNC:7989   | NRAS     |
+| HGNC:9588   | PTEN     |
+| HGNC:12805  | XDH      |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hgnc_code_symbol_mapper_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|637.5 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_mapper_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_mapper_2026_en.md
@@ -1,6 +1,6 @@
 ---
 layout: model
-title: Mapping Gene Mentions in Text with Their Corresponding HGNC Codes
+title: Mapping Gene Entities in Text with Their Corresponding HGNC Codes
 author: John Snow Labs
 name: hgnc_mapper_2026
 date: 2026-08-07

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_mapper_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_mapper_2026_en.md
@@ -1,0 +1,186 @@
+---
+layout: model
+title: Mapping Gene Mentions in Text with Their Corresponding HGNC Codes
+author: John Snow Labs
+name: hgnc_mapper_2026
+date: 2026-08-07
+tags: [en, chunk_mapper, licensed, clinical, hgnc, gene]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene mentions extracted from clinical or biomedical text to their corresponding HUGO Gene Nomenclature Committee (HGNC) identifiers, using current approved gene symbols and official names. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hgnc_mapper_2026_en_6.4.1_3.4_1786113006137.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hgnc_mapper_2026_en_6.4.1_3.4_1786113006137.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_hgnc = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+hgnc_mapper = ChunkMapperModel.pretrained("hgnc_mapper_2026","en","clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hgnc_id"])\
+    .setLowerCase(True)
+
+pipeline = Pipeline(stages=[\
+    document_assembler, sentence_detector, tokenizer, word_embeddings,\
+    ner_hgnc, ner_converter, hgnc_mapper\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_hgnc = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+hgnc_mapper = medical.ChunkMapperModel.pretrained("hgnc_mapper_2026","en","clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hgnc_id"])\
+    .setLowerCase(True)
+
+pipeline = nlp.Pipeline(stages=[\
+    document_assembler, sentence_detector, tokenizer, word_embeddings,\
+    ner_hgnc, ner_converter, hgnc_mapper\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val wordEmbeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val nerHgnc = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val nerConverter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("GENE"))
+
+val hgncMapper = ChunkMapperModel
+    .pretrained("hgnc_mapper_2026", "en", "clinical/models")
+    .setInputCols("ner_chunk")
+    .setOutputCol("mappings")
+    .setRels(Array("hgnc_id"))
+    .setLowerCase(true)
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, wordEmbeddings,
+    nerHgnc, nerConverter, hgncMapper
+))
+
+val data = Seq("Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes.").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| chunk   | HGNC Code   | all_k_resolutions   |
+|:--------|:------------|:--------------------|
+| BRCA1   | HGNC:1100   | HGNC:1100:::        |
+| EGFR    | HGNC:3236   | HGNC:3236:::        |
+| KRAS    | HGNC:6407   | HGNC:6407:::        |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hgnc_mapper_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|1.6 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_mapper_augmented_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_mapper_augmented_2026_en.md
@@ -1,0 +1,186 @@
+---
+layout: model
+title: Mapping Gene Entities with Corresponding HGNC Codes - Augmented
+author: John Snow Labs
+name: hgnc_mapper_augmented_2026
+date: 2026-08-07
+tags: [en, chunk_mapper, licensed, clinical, hgnc, gene, augmented]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene mentions extracted from clinical or biomedical text to their corresponding HUGO Gene Nomenclature Committee (HGNC) identifiers, including known alias and previous gene symbols/names in addition to current approved ones. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hgnc_mapper_augmented_2026_en_6.4.1_3.4_1786130924887.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hgnc_mapper_augmented_2026_en_6.4.1_3.4_1786130924887.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_hgnc = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+hgnc_mapper = ChunkMapperModel.pretrained("hgnc_mapper_augmented_2026","en","clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hgnc_id"])\
+    .setLowerCase(True)
+
+pipeline = Pipeline(stages=[\
+    document_assembler, sentence_detector, tokenizer, word_embeddings,\
+    ner_hgnc, ner_converter, hgnc_mapper\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentence_detector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_hgnc = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+hgnc_mapper = medical.ChunkMapperModel.pretrained("hgnc_mapper_augmented_2026","en","clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hgnc_id"])\
+    .setLowerCase(True)
+
+pipeline = nlp.Pipeline(stages=[\
+    document_assembler, sentence_detector, tokenizer, word_embeddings,\
+    ner_hgnc, ner_converter, hgnc_mapper\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val wordEmbeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val nerHgnc = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val nerConverter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("GENE"))
+
+val hgncMapper = ChunkMapperModel
+    .pretrained("hgnc_mapper_augmented_2026", "en", "clinical/models")
+    .setInputCols("ner_chunk")
+    .setOutputCol("mappings")
+    .setRels(Array("hgnc_id"))
+    .setLowerCase(true)
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, wordEmbeddings,
+    nerHgnc, nerConverter, hgncMapper
+))
+
+val data = Seq("Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes.").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| chunk   | HGNC Code   | all_k_resolutions   |
+|:--------|:------------|:--------------------|
+| BRCA1   | HGNC:1100   | HGNC:1100:::        |
+| EGFR    | HGNC:3236   | HGNC:3236:::        |
+| KRAS    | HGNC:6407   | HGNC:6407:::        |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hgnc_mapper_augmented_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|3.6 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_symbol_code_mapper_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-hgnc_symbol_code_mapper_2026_en.md
@@ -1,0 +1,126 @@
+---
+layout: model
+title: Mapping Gene Symbols with Their Corresponding HGNC Codes
+author: John Snow Labs
+name: hgnc_symbol_code_mapper_2026
+date: 2026-08-07
+tags: [en, chunk_mapper, licensed, clinical, hgnc, gene]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps current approved gene symbols to their corresponding HGNC identifier. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/hgnc_symbol_code_mapper_2026_en_6.4.1_3.4_1786132264719.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/hgnc_symbol_code_mapper_2026_en_6.4.1_3.4_1786132264719.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+code_mapper = ChunkMapperModel.pretrained("hgnc_symbol_code_mapper_2026","en","clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hgnc_id"])
+
+pipeline = Pipeline(stages=[document_assembler, chunk_assembler, code_mapper])
+
+data = spark.createDataFrame([[s] for s in ['TP53', 'BRCA1', 'EGFR', 'KRAS', 'APC', 'NRAS', 'PTEN', 'XDH']]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+chunk_assembler = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+code_mapper = medical.ChunkMapperModel.pretrained("hgnc_symbol_code_mapper_2026","en","clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["hgnc_id"])
+
+pipeline = nlp.Pipeline(stages=[document_assembler, chunk_assembler, code_mapper])
+
+data = spark.createDataFrame([[s] for s in ['TP53', 'BRCA1', 'EGFR', 'KRAS', 'APC', 'NRAS', 'PTEN', 'XDH']]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val chunkAssembler = new Doc2Chunk()
+    .setInputCols("document")
+    .setOutputCol("ner_chunk")
+
+val codeMapper = ChunkMapperModel
+    .pretrained("hgnc_symbol_code_mapper_2026", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("hgnc_id"))
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, chunkAssembler, codeMapper))
+
+val data = Seq("TP53", "BRCA1", "EGFR", "KRAS", "APC", "NRAS", "PTEN", "XDH").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| symbol   | HGNC Code   |
+|:---------|:------------|
+| TP53     | HGNC:11998  |
+| BRCA1    | HGNC:1100   |
+| EGFR     | HGNC:3236   |
+| KRAS     | HGNC:6407   |
+| APC      | HGNC:583    |
+| NRAS     | HGNC:7989   |
+| PTEN     | HGNC:9588   |
+| XDH      | HGNC:12805  |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|hgnc_symbol_code_mapper_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|618.4 KB|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-sbiobertresolve_hgnc_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-sbiobertresolve_hgnc_2026_en.md
@@ -1,0 +1,212 @@
+---
+layout: model
+title: Sentence Entity Resolver for HGNC Gene Symbols (sbiobert_base_cased_mli_onnx Embeddings)
+author: John Snow Labs
+name: sbiobertresolve_hgnc_2026
+date: 2026-08-07
+tags: [en, entity_resolution, licensed, clinical, hgnc, gene, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene symbols and official names to HUGO Gene Nomenclature Committee (HGNC) identifiers using `sbiobert_base_cased_mli_onnx` embeddings. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_hgnc_2026_en_6.4.1_3.4_1786106342222.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_hgnc_2026_en_6.4.1_3.4_1786106342222.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_hgnc_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_hgnc_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("GENE"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_hgnc_2026", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk   | entity   | HGNC Code   | Resolution                              | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:------------|:---------|:------------|:----------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| BRCA1       | GENE     | HGNC:1100   | BRCA1 [BRCA1 DNA repair associated]     | HGNC:1100:::HGNC:18994:::HGNC:23057:::HGNC:28153:::HGNC:24170:::HGNC:11551:::HGN... | 0.0000:::0.0269:::0.0295:::0.0320:::0.0324:::0.0329:::0.0327:::0.0339:::0.0366::... | BRCA1 [BRCA1 DNA repair associated]:::BRSK1 [BR serine/threonine kinase 1]:::BRK... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| EGFR        | GENE     | HGNC:3236   | EGFR [epidermal growth factor receptor] | HGNC:3236:::HGNC:3229:::HGNC:3697:::HGNC:16898:::HGNC:12691:::HGNC:4194:::HGNC:2... | 0.0000:::0.0178:::0.0428:::0.0500:::0.0497:::0.0533:::0.0555:::0.0581:::0.0600::... | EGFR [epidermal growth factor receptor]:::EGF [epidermal growth factor]:::FGR [F... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| KRAS        | GENE     | HGNC:6407   | KRAS [KRas proto-oncogene, GTPase]      | HGNC:6407:::HGNC:58375:::HGNC:6406:::HGNC:56729:::HGNC:15865:::HGNC:6308:::HGNC:... | 0.0000:::0.1054:::0.1097:::0.1096:::0.1083:::0.1161:::0.1178:::0.1234:::0.1186::... | KRAS [KRas proto-oncogene, GTPase]:::KDNBY [KDM5D neighbour, Y-linked]:::KRASP1 ... | protein-coding gene :: gene with protein product:::non-coding RNA :: RNA, long n... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_hgnc_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|260.2 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-07-sbiobertresolve_hgnc_augmented_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-07-sbiobertresolve_hgnc_augmented_2026_en.md
@@ -1,0 +1,212 @@
+---
+layout: model
+title: Sentence Entity Resolver for HGNC Gene Symbols - Augmented (sbiobert_base_cased_mli_onnx Embeddings)
+author: John Snow Labs
+name: sbiobertresolve_hgnc_augmented_2026
+date: 2026-08-07
+tags: [en, entity_resolution, licensed, clinical, hgnc, gene, sbiobert, augmented]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps gene symbols, official names, and their known alias/previous symbols and names to HUGO Gene Nomenclature Committee (HGNC) identifiers using `sbiobert_base_cased_mli_onnx` embeddings. Trained on the HGNC monthly release dated 2026-08-04.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786108286686.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_hgnc_augmented_2026_en_6.4.1_3.4_1786108286686.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_hgnc_augmented_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetector = nlp.SentenceDetector()\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_human_phenotype_gene_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")\
+    .setWhiteList(["GENE"])
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols("ner_chunk")\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_hgnc_augmented_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_human_phenotype_gene_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+    .setWhiteList(Array("GENE"))
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols("ner_chunk")
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_hgnc_augmented_2026", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetector, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("Genetic testing confirmed a pathogenic BRCA1 variant, and the report also flagged elevated risk associated with the EGFR and KRAS genes.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk   | entity   | HGNC Code   | Resolution                              | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   | all_k_aux_labels                                                                    |
+|:------------|:---------|:------------|:----------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| BRCA1       | GENE     | HGNC:1100   | BRCA1 [BRCA1 DNA repair associated]     | HGNC:1100:::HGNC:15550:::HGNC:29885:::HGNC:18994:::HGNC:23057:::HGNC:28153:::HGN... | 0.0000:::0.0119:::0.0145:::0.0269:::0.0295:::0.0320:::0.0324:::0.0329:::0.0335::... | BRCA1 [BRCA1 DNA repair associated]:::BRCAA1 [AT-rich interaction domain 4B]:::B... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| EGFR        | GENE     | HGNC:3236   | EGFR [epidermal growth factor receptor] | HGNC:3236:::HGNC:3229:::HGNC:13780:::HGNC:18454:::HGNC:12932:::HGNC:14270:::HGNC... | 0.0000:::0.0178:::0.0308:::0.0333:::0.0349:::0.0366:::0.0428:::0.0452:::0.0499::... | EGFR [epidermal growth factor receptor]:::EGF [epidermal growth factor]:::EFGM [... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+| KRAS        | GENE     | HGNC:6407   | KRAS [KRas proto-oncogene, GTPase]      | HGNC:6407:::HGNC:28330:::HGNC:25121:::HGNC:11322:::HGNC:11319:::HGNC:19118:::HGN... | 0.0000:::0.0762:::0.0787:::0.0885:::0.0890:::0.0899:::0.0899:::0.0875:::0.0970::... | KRAS [KRas proto-oncogene, GTPase]:::kish [transmembrane protein 167A]:::KRASIM ... | protein-coding gene :: gene with protein product:::protein-coding gene :: gene w... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_hgnc_augmented_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[resolution]|
+|Language:|en|
+|Size:|565.2 MB|
+|Case sensitive:|false|


### PR DESCRIPTION
# HGNC 20260806 — Resolver & Mapper Update

Adds/updates 6 resolvers and 4 mappers for HGNC (HUGO Gene Nomenclature Committee), release 2026-08 (45,031 approved genes, verified byte-identical to the live HGNC source as of 2026-08-04).

## Models
| Model | Type | Embedding | Status |
|---|---|---|---|
| `sbiobertresolve_hgnc_2026` | Sentence Entity Resolver | sbiobert_base_cased_mli_onnx | Updated — new versioned name succeeding the existing (2023) `sbiobertresolve_hgnc`, retrained on current data |
| `biolordresolve_hgnc_2026` | Sentence Entity Resolver | mpnet_embeddings_biolord_2023_c | New |
| `bgeresolve_hgnc_2026` | Sentence Entity Resolver | bge_base_en_v1_5_onnx | New |
| `sbiobertresolve_hgnc_augmented_2026` | Sentence Entity Resolver | sbiobert_base_cased_mli_onnx | New — augmented scope, adds alias/previous gene symbols and names |
| `biolordresolve_hgnc_augmented_2026` | Sentence Entity Resolver | mpnet_embeddings_biolord_2023_c | New — augmented scope |
| `bgeresolve_hgnc_augmented_2026` | Sentence Entity Resolver | bge_base_en_v1_5_onnx | New — augmented scope |
| `hgnc_mapper_2026` | Chunk Mapper | — | New — gene mention (text) → HGNC ID direct lookup, 90,040 dictionary entries |
| `hgnc_mapper_augmented_2026` | Chunk Mapper | — | New — gene mention (text) → HGNC ID, augmented scope, 195,559 dictionary entries |
| `hgnc_code_symbol_mapper_2026` | Chunk Mapper | — | New — HGNC ID → gene symbol direct lookup, 45,031 dictionary entries |
| `hgnc_symbol_code_mapper_2026` | Chunk Mapper | — | New — gene symbol → HGNC ID direct lookup, 45,031 dictionary entries |

## Data
Trained on the current CMS/HGNC gene nomenclature master file (verified byte-identical via SHA256 to the live HGNC source, 2026-08-04) — 45,031 approved genes.

## Distribution
All 10 models live on JSL Models Hub.
