### PR TITLE
2026-08-10-mesh_mapper_2026_en

### DIFF
--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-bgeresolve_mesh_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-bgeresolve_mesh_2026_en.md
@@ -1,0 +1,213 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes (bge_base_en_v1_5_onnx Embeddings)
+author: John Snow Labs
+name: bgeresolve_mesh_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `bge_base_en_v1_5_onnx` Sentence Embeddings.
+
+Trained on the MeSH 2026 dataset (NLM-native descriptors, entry terms, supplemental concept records, and pharmacologic actions only).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_mesh_2026_en_6.4.1_3.4_1786393893621.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_mesh_2026_en_6.4.1_3.4_1786393893621.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_mesh_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_mesh_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_mesh_2026", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | MeSH Code   | Resolution            | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:------------|:----------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| diabetes mellitus     | PROBLEM  | D003920     | diabetes mellitus     | D003920:::D003924:::D003922:::D048909:::D000071698:::D016640:::C563959:::C566602... | 0.0000:::0.1077:::0.1174:::0.1290:::0.1528:::0.1642:::0.1884:::0.1911:::0.1949::... | diabetes mellitus:::type 2 diabetes mellitus:::type 1 diabetes mellitus:::diabet... |
+| hypertension          | PROBLEM  | D006973     | hypertension          | D006973:::D001794:::D006977:::D000092244:::D000075222:::D000959:::D000096003:::D... | 0.0000:::0.0933:::0.1142:::0.1500:::0.1896:::0.1966:::0.2072:::0.2082:::0.2084::... | hypertension:::blood pressure:::renal hypertension:::systolic hypertension:::ess... |
+| pneumonia             | PROBLEM  | D011014     | pneumonia             | D011014:::D011018:::D018410:::D001996:::D011024:::D011019:::D011020:::D017564:::... | 0.0000:::0.1131:::0.1131:::0.1355:::0.1498:::0.1626:::0.1719:::0.1750:::0.1780::... | pneumonia:::pneumococcal pneumonia:::bacterial pneumonia:::bronchial pneumonia::... |
+| myocardial infarction | PROBLEM  | D009203     | myocardial infarction | D009203:::D007238:::D017202:::D000789:::D000072658:::D056989:::D000072657           | 0.0000:::0.1326:::0.1335:::0.1668:::0.1751:::0.1806:::0.1865                        | myocardial infarction:::infarction:::myocardial ischemia:::myocardial preinfarct... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_mesh_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|1.7 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-bgeresolve_mesh_augmented_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-bgeresolve_mesh_augmented_2026_en.md
@@ -1,0 +1,211 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes - Augmented (bge_base_en_v1_5_onnx Embeddings)
+author: John Snow Labs
+name: bgeresolve_mesh_augmented_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, bge, augmented]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `bge_base_en_v1_5_onnx` Sentence Embeddings.
+
+Trained on the MeSH 2026 augmented dataset (NLM-native content plus an expanded synonym pool).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_mesh_augmented_2026_en_6.4.1_3.4_1786394778754.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_mesh_augmented_2026_en_6.4.1_3.4_1786394778754.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_mesh_augmented_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient received vaccination and was also being monitored for tuberculosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_mesh_augmented_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient received vaccination and was also being monitored for tuberculosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_mesh_augmented_2026", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The patient received vaccination and was also being monitored for tuberculosis.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk    | entity    | MeSH Code   | Resolution   | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:-------------|:----------|:------------|:-------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| vaccination  | TREATMENT | D014611     | vaccination  | D014611:::D007114:::D000073887:::D000078782:::D032541:::D000088823:::D004673:::D... | 0.0000:::0.1301:::0.1560:::0.1718:::0.1885:::0.1888:::0.1915:::0.1924:::0.1937      | vaccination:::immunization:::vaccination coverage:::vaccinology:::vaccination, m... |
+| tuberculosis | PROBLEM   | D014376     | tuberculosis | D014376:::D000099298:::D009169:::D014397:::D014379:::D014388:::D014396:::D014378... | 0.0000:::0.1047:::0.1073:::0.1251:::0.1817:::0.1913:::0.1947:::0.2081:::0.2100::... | tuberculosis:::tuberculosis disease:::mycobacterium tuberculosis:::pulmonary tub... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_mesh_augmented_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|2.9 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-bgeresolve_mesh_veterinary_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-bgeresolve_mesh_veterinary_2026_en.md
@@ -1,0 +1,213 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes - Veterinary (bge_base_en_v1_5_onnx Embeddings)
+author: John Snow Labs
+name: bgeresolve_mesh_veterinary_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, bge, veterinary]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `bge_base_en_v1_5_onnx` Sentence Embeddings.
+
+Trained on the MeSH 2026 dataset, augmented by JSL with a veterinary-focused scope.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_mesh_veterinary_2026_en_6.4.1_3.4_1786395767689.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_mesh_veterinary_2026_en_6.4.1_3.4_1786395767689.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_mesh_veterinary_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_mesh_veterinary_2026","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_mesh_veterinary_2026", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk         | entity    | MeSH Code   | Resolution        | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:------------------|:----------|:------------|:------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| rabies            | PROBLEM   | D011818     | rabies            | D011818:::D011820:::D018114:::D017992                                               | 0.0000:::0.0597:::0.2011:::0.2824                                                   | rabies:::rabies virus:::rabies virus group:::parvovirus, raccoon                    |
+| vaccination       | TREATMENT | D014611     | vaccination       | D014611:::D007114:::D032541:::D004673:::D007117:::D003888                           | 0.0000:::0.1301:::0.1885:::0.1915:::0.1979:::0.2168                                 | vaccination:::immunization:::vaccination, mass:::vaccination encephalitis:::boos... |
+| tick infestations | PROBLEM   | D013984     | tick infestations | D013984:::D013987:::D064927:::D004478:::D000712:::D008924:::D026863:::D017282:::... | 0.0000:::0.1277:::0.1788:::0.1809:::0.1847:::0.1860:::0.2003:::0.2039:::0.2056::... | tick infestations:::ticks:::tick bites:::ectoparasitic infestations:::tick fever... |
+| coccidiosis       | PROBLEM   | D003048     | coccidiosis       | D003048:::D003047                                                                   | 0.0000:::0.1034                                                                     | coccidiosis:::coccidioidomycosis                                                    |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_mesh_veterinary_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|539.7 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-biolordresolve_mesh_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-biolordresolve_mesh_2026_en.md
@@ -1,0 +1,216 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes (mpnet_embeddings_biolord_2023_c Embeddings)
+author: John Snow Labs
+name: biolordresolve_mesh_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `mpnet_embeddings_biolord_2023_c` Sentence Embeddings.
+
+Trained on the MeSH 2026 dataset (NLM-native descriptors, entry terms, supplemental concept records, and pharmacologic actions only).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_mesh_2026_en_6.4.1_3.4_1786393391468.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_mesh_2026_en_6.4.1_3.4_1786393391468.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_mesh_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_mesh_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("embeddings")
+    .setCaseSensitive(false)
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_mesh_2026", "en", "clinical/models")
+    .setInputCols(Array("embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | MeSH Code   | Resolution            | all_k_results                                                      | all_k_cosine_distances                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:------------|:----------------------|:-------------------------------------------------------------------|:----------------------------------------------------|:------------------------------------------------------------------------------------|
+| diabetes mellitus     | PROBLEM  | D003920     | diabetes mellitus     | D003920:::D005905:::C070071:::D003924:::D003922:::D002271          | 0.0000:::0.0755:::0.0978:::0.1024:::0.1100:::0.1429 | diabetes mellitus:::diabeta:::diabeton:::noninsulin dependent diabetes mellitus:... |
+| hypertension          | PROBLEM  | D006973     | hypertension          | D006973:::D000075222:::D000096003:::D006974:::D058246:::D000092244 | 0.0000:::0.1106:::0.1139:::0.1724:::0.1804:::0.1828 | hypertension:::hypertension, essential:::hypertensive crises:::malignant hyperte... |
+| pneumonia             | PROBLEM  | D011014     | pneumonia             | D011014:::D001996:::D018410:::D000098968:::D000092124              | 0.0000:::0.2264:::0.2603:::0.2638:::0.2705          | pneumonia:::bronchial pneumonias:::bacterial pneumonias:::community acquired pne... |
+| myocardial infarction | PROBLEM  | D009203     | myocardial infarction | D009203:::D056989:::D056988:::D000088442                           | 0.0000:::0.1924:::0.1937:::0.2328                   | myocardial infarction:::diaphragmatic myocardial infarctions:::anteroseptal myoc... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_mesh_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|1.7 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-biolordresolve_mesh_augmented_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-biolordresolve_mesh_augmented_2026_en.md
@@ -1,0 +1,214 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes - Augmented (mpnet_embeddings_biolord_2023_c Embeddings)
+author: John Snow Labs
+name: biolordresolve_mesh_augmented_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, biolord, augmented]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `mpnet_embeddings_biolord_2023_c` Sentence Embeddings.
+
+Trained on the MeSH 2026 augmented dataset (NLM-native content plus an expanded synonym pool).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_mesh_augmented_2026_en_6.4.1_3.4_1786394768633.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_mesh_augmented_2026_en_6.4.1_3.4_1786394768633.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_mesh_augmented_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient received vaccination and was also being monitored for tuberculosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_mesh_augmented_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient received vaccination and was also being monitored for tuberculosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("embeddings")
+    .setCaseSensitive(false)
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_mesh_augmented_2026", "en", "clinical/models")
+    .setInputCols(Array("embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The patient received vaccination and was also being monitored for tuberculosis.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk    | entity    | MeSH Code   | Resolution   | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:-------------|:----------|:------------|:-------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| vaccination  | TREATMENT | D014611     | vaccination  | D014611:::D007114:::D007117:::D017589:::D000095498:::C050598:::D000073887:::D016... | 0.0000:::0.0512:::0.0791:::0.0983:::0.1045:::0.1191:::0.1273:::0.1369               | vaccination:::immunization:::booster immunizations:::vaccination campaigns:::com... |
+| tuberculosis | PROBLEM   | D014376     | tuberculosis | D014376:::D000099298:::D009169:::D014375:::D009170:::C536092:::D000092225:::C000... | 0.0000:::0.0749:::0.1750:::0.1935:::0.2165:::0.2467:::0.2544:::0.2597:::0.2643::... | tuberculosis:::tuberculosis disease:::mycobacterium tuberculosis:::tuberculomas:... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_mesh_augmented_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|2.9 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-biolordresolve_mesh_veterinary_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-biolordresolve_mesh_veterinary_2026_en.md
@@ -1,0 +1,216 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes - Veterinary (mpnet_embeddings_biolord_2023_c Embeddings)
+author: John Snow Labs
+name: biolordresolve_mesh_veterinary_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, biolord, veterinary]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `mpnet_embeddings_biolord_2023_c` Sentence Embeddings.
+
+Trained on the MeSH 2026 dataset, augmented by JSL with a veterinary-focused scope.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_mesh_veterinary_2026_en_6.4.1_3.4_1786395759906.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_mesh_veterinary_2026_en_6.4.1_3.4_1786395759906.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_mesh_veterinary_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("embeddings")\
+    .setCaseSensitive(False)\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_mesh_veterinary_2026","en","clinical/models")\
+    .setInputCols(["embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("embeddings")
+    .setCaseSensitive(false)
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_mesh_veterinary_2026", "en", "clinical/models")
+    .setInputCols(Array("embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk         | entity    | MeSH Code   | Resolution        | all_k_results                         | all_k_cosine_distances            | all_k_resolutions                                                     |
+|:------------------|:----------|:------------|:------------------|:--------------------------------------|:----------------------------------|:----------------------------------------------------------------------|
+| rabies            | PROBLEM   | D011818     | rabies            | D011818:::D011820:::D018114:::D012400 | 0.0000:::0.1126:::0.1725:::0.3992 | rabies:::rabies virus:::genus: rabies virus group:::rotavirus disease |
+| vaccination       | TREATMENT | D014611     | vaccination       | D014611:::D007114:::D007117           | 0.0000:::0.0512:::0.0596          | vaccination:::immunization:::booster vaccination                      |
+| tick infestations | PROBLEM   | D013984     | tick infestations | D013984:::D017282                     | 0.0000:::0.1426                   | tick infestations:::borne diseases, tick                              |
+| coccidiosis       | PROBLEM   | D003048     | coccidiosis       | D003048:::D003047:::D021865           | 0.0000:::0.1142:::0.2484          | coccidiosis:::coccidioides infections:::isosporiasis                  |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_mesh_veterinary_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|540.0 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-mesh_mapper_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-mesh_mapper_2026_en.md
@@ -1,0 +1,135 @@
+---
+layout: model
+title: Mapping Entities with Corresponding MeSH Codes
+author: John Snow Labs
+name: mesh_mapper_2026
+date: 2026-08-10
+tags: [en, chunk_mapper, licensed, clinical, mesh]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps entities extracted from text to their corresponding MeSH (Medical Subject Headings) codes.
+
+It performs a direct lookup against the full training text, providing fast, exact-match code mapping without requiring embeddings at inference time.
+
+Trained on the current NLM MeSH descriptor, entry-term, and supplemental-concept dataset (release 2026).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/mesh_mapper_2026_en_6.4.1_3.4_1786390913135.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/mesh_mapper_2026_en_6.4.1_3.4_1786390913135.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+document_assembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+mesh_mapper = ChunkMapperModel.pretrained("mesh_mapper_2026", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["mesh_code"])
+
+pipeline = Pipeline(stages=[
+    document_assembler, doc2chunk, mesh_mapper
+])
+
+data = spark.createDataFrame([["diabetes mellitus"],["aspirin"],["rabies"],["diet"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+document_assembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+doc2chunk = nlp.Doc2Chunk()\
+    .setInputCols(["document"])\
+    .setOutputCol("ner_chunk")
+
+mesh_mapper = medical.ChunkMapperModel.pretrained("mesh_mapper_2026", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["mesh_code"])
+
+pipeline = nlp.Pipeline(stages=[
+    document_assembler, doc2chunk, mesh_mapper
+])
+
+data = spark.createDataFrame([["diabetes mellitus"],["aspirin"],["rabies"],["diet"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val doc2Chunk = new Doc2Chunk()
+    .setInputCols(Array("document"))
+    .setOutputCol("ner_chunk")
+
+val meshMapper = ChunkMapperModel.pretrained("mesh_mapper_2026", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("mesh_code"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, doc2Chunk, meshMapper
+))
+
+val data = Seq("diabetes mellitus","aspirin","rabies","diet").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk         | mesh_code   |
+|:------------------|:------------|
+| diabetes mellitus | D003920     |
+| aspirin           | D001241     |
+| rabies            | D011818     |
+| diet              | D004032     |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|mesh_mapper_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|24.8 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-sbiobertresolve_mesh_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-sbiobertresolve_mesh_2026_en.md
@@ -1,0 +1,213 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes (sbiobert_base_cased_mli_onnx Embeddings)
+author: John Snow Labs
+name: sbiobertresolve_mesh_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `sbiobert_base_cased_mli_onnx` Sentence Embeddings.
+
+Trained on the MeSH 2026 dataset (NLM-native descriptors, entry terms, supplemental concept records, and pharmacologic actions only).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_mesh_2026_en_6.4.1_3.4_1786392589795.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_mesh_2026_en_6.4.1_3.4_1786392589795.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_mesh_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_mesh_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_mesh_2026", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The patient has a long history of diabetes mellitus and hypertension, and presented today with pneumonia and possible myocardial infarction.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | MeSH Code   | Resolution            | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:------------|:----------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| diabetes mellitus     | PROBLEM  | D003920     | diabetes mellitus     | D003920:::D048909:::D003922:::D003924:::D000099074:::D003923:::D005905:::D003921    | 0.0000:::0.0271:::0.0333:::0.0445:::0.0479:::0.0647:::0.0800:::0.0790               | diabetes mellitus:::complications of diabetes mellitus:::insulin-dependent diabe... |
+| hypertension          | PROBLEM  | D006973     | hypertension          | D006973:::D000075222:::D000802:::C072778:::D059468:::D000092244:::D058246:::D009... | 0.0000:::0.0340:::0.0350:::0.0403:::0.0457:::0.0636:::0.0685:::0.0735:::0.0789::... | hypertension:::essential hypertension:::hypertensin:::hypertensive factor:::hype... |
+| pneumonia             | PROBLEM  | D011014     | pneumonia             | D011014:::D000092124:::D018410:::D011020:::D000098968:::D011015:::D007711:::D000... | 0.0000:::0.0754:::0.0891:::0.1197:::0.1175:::0.1202:::0.1271:::0.1243:::0.1296::... | pneumonia:::organizing pneumonia:::bacterial pneumonia:::pneumonia, pcp:::commun... |
+| myocardial infarction | PROBLEM  | D009203     | myocardial infarction | D009203:::D056989:::D056988:::D000072657:::D002544:::D020243                        | 0.0000:::0.0269:::0.0306:::0.0354:::0.0547:::0.0583                                 | myocardial infarction:::inferior myocardial infarction:::anterior wall myocardia... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_mesh_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|1.7 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-sbiobertresolve_mesh_augmented_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-sbiobertresolve_mesh_augmented_2026_en.md
@@ -1,0 +1,211 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes - Augmented (sbiobert_base_cased_mli_onnx Embeddings)
+author: John Snow Labs
+name: sbiobertresolve_mesh_augmented_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, sbiobert, augmented]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `sbiobert_base_cased_mli_onnx` Sentence Embeddings.
+
+Trained on the MeSH 2026 augmented dataset (NLM-native content plus an expanded synonym pool).
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_mesh_augmented_2026_en_6.4.1_3.4_1786394695359.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_mesh_augmented_2026_en_6.4.1_3.4_1786394695359.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_mesh_augmented_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient received vaccination and was also being monitored for tuberculosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_mesh_augmented_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient received vaccination and was also being monitored for tuberculosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_mesh_augmented_2026", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The patient received vaccination and was also being monitored for tuberculosis.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk    | entity    | MeSH Code   | Resolution   | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:-------------|:----------|:------------|:-------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| vaccination  | TREATMENT | D014611     | vaccination  | D014611:::C050598:::D000078782:::D007114:::D000095498:::D017589:::D000073887:::C... | 0.0000:::0.0162:::0.0438:::0.0467:::0.0546:::0.0565:::0.0593:::0.0812:::0.0803::... | vaccination:::vaccin:::vaccinology:::immunization:::mandated vaccination:::vacci... |
+| tuberculosis | PROBLEM   | D014376     | tuberculosis | D014376:::D000099298:::D014378:::D014397:::D006763:::D009169:::D014391:::D018088... | 0.0000:::0.0529:::0.0697:::0.1039:::0.1112:::0.1157:::0.1304:::0.1326:::0.1310::... | tuberculosis:::tuberculosis disease:::tuberculosis societies:::pulmonary tubercu... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_mesh_augmented_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|2.9 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-08-10-sbiobertresolve_mesh_veterinary_2026_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-08-10-sbiobertresolve_mesh_veterinary_2026_en.md
@@ -1,0 +1,213 @@
+---
+layout: model
+title: Sentence Entity Resolver for MeSH Codes - Veterinary (sbiobert_base_cased_mli_onnx Embeddings)
+author: John Snow Labs
+name: sbiobertresolve_mesh_veterinary_2026
+date: 2026-08-10
+tags: [en, entity_resolution, licensed, clinical, mesh, sbiobert, veterinary]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps clinical/veterinary entities to MeSH (Medical Subject Headings) Unique Identifiers (UI) using `sbiobert_base_cased_mli_onnx` Sentence Embeddings.
+
+Trained on the MeSH 2026 dataset, augmented by JSL with a veterinary-focused scope.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_mesh_veterinary_2026_en_6.4.1_3.4_1786395752523.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_mesh_veterinary_2026_en_6.4.1_3.4_1786395752523.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = MedicalNerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_mesh_veterinary_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("word_embeddings")
+
+ner_model = medical.NerModel.pretrained("ner_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token","word_embeddings"])\
+    .setOutputCol("ner")
+
+ner_converter = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner"])\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_mesh_veterinary_2026","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("mesh_code")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_model, ner_converter, chunk2doc, embedder, resolver\
+])
+
+data = spark.createDataFrame([["The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("word_embeddings")
+
+val ner_model = MedicalNerModel
+    .pretrained("ner_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "word_embeddings"))
+    .setOutputCol("ner")
+
+val ner_converter = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_mesh_veterinary_2026", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("mesh_code")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_model, ner_converter, chunk2doc, embedder, resolver
+))
+
+val data = Seq("The dog was diagnosed with rabies and treated with vaccination; tick infestations were also noted, along with coccidiosis.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk         | entity    | MeSH Code   | Resolution        | all_k_results                                   | all_k_cosine_distances                     | all_k_resolutions                                                                   |
+|:------------------|:----------|:------------|:------------------|:------------------------------------------------|:-------------------------------------------|:------------------------------------------------------------------------------------|
+| rabies            | PROBLEM   | D011818     | rabies            | D011818:::D011820:::D018114:::C000639155        | 0.0000:::0.0501:::0.1049:::0.2105          | rabies:::rabies virus:::rabies virus group:::rickettsia gravesii                    |
+| vaccination       | TREATMENT | D014611     | vaccination       | D014611:::D007114:::D032541:::D007117:::D007115 | 0.0000:::0.0467:::0.0803:::0.0802:::0.0872 | vaccination:::immunization:::mass vaccination:::booster vaccination:::immunizati... |
+| tick infestations | PROBLEM   | D013984     | tick infestations | D013984:::D064927:::D017282:::D013987           | 0.0000:::0.0601:::0.0700:::0.0736          | tick infestations:::tick bites:::tick-borne infections:::tick parasite              |
+| coccidiosis       | PROBLEM   | D003048     | coccidiosis       | D003048:::D003047:::D010229                     | 0.0000:::0.0423:::0.0941                   | coccidiosis:::coccidioides infection:::paracoccidioides infections                  |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_mesh_veterinary_2026|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[mesh_code]|
+|Language:|en|
+|Size:|538.8 MB|
+|Case sensitive:|false|


### PR DESCRIPTION
# MeSH 2026 — Resolver & Mapper Update

Adds/updates 9 resolvers and 1 mapper for MeSH (Medical Subject Headings), release 2026 (three training scopes — plain, augmented, veterinary — covering 355,135 / 355,362 / 29,964 distinct codes respectively).

## Models
| Model | Type | Embedding | Status |
|---|---|---|---|
| `mesh_mapper_2026` | Chunk Mapper | — | New — 1,015,056-entry exact-match dictionary |
| `sbiobertresolve_mesh_2026` | Sentence Entity Resolver | sbiobert_base_cased_mli_onnx | Updated — versioned successor to `sbiobertresolve_mesh` |
| `biolordresolve_mesh_2026` | Sentence Entity Resolver | mpnet_embeddings_biolord_2023_c | New |
| `bgeresolve_mesh_2026` | Sentence Entity Resolver | bge_base_en_v1_5_onnx | New |
| `sbiobertresolve_mesh_augmented_2026` | Sentence Entity Resolver | sbiobert_base_cased_mli_onnx | Updated — versioned successor to `sbiobertresolve_mesh_augmented` |
| `biolordresolve_mesh_augmented_2026` | Sentence Entity Resolver | mpnet_embeddings_biolord_2023_c | New |
| `bgeresolve_mesh_augmented_2026` | Sentence Entity Resolver | bge_base_en_v1_5_onnx | New |
| `sbiobertresolve_mesh_veterinary_2026` | Sentence Entity Resolver | sbiobert_base_cased_mli_onnx | Updated — versioned successor to `sbiobertresolve_mesh_veterinary` |
| `biolordresolve_mesh_veterinary_2026` | Sentence Entity Resolver | mpnet_embeddings_biolord_2023_c | New |
| `bgeresolve_mesh_veterinary_2026` | Sentence Entity Resolver | bge_base_en_v1_5_onnx | New |

## Data
Trained on NLM's MeSH 2026 descriptor, entry-term, supplemental-concept, and pharmacologic-action files, with the augmented target additionally trained on Athena/OMOP synonym enrichment and the veterinary target trained on a real-usage PubMed citation census of veterinary-tagged descriptors (5,501 confirmed terms), release 2026.

## Distribution
All 10 models live on JSL Models Hub.
