### PR TITLE
Loinc 2.83 Update (Models-Mappers-Pipelines)

### DIFF
--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-bgeresolve_loinc_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-bgeresolve_loinc_2_83_en.md
@@ -1,0 +1,265 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (bge_base_en_v1_5_onnx embeddings)
+author: John Snow Labs
+name: bgeresolve_loinc_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `bge_base_en_v1_5_onnx` embeddings.
+
+Trained on the official LOINC 2.83 dataset.
+
+This model may also resolve to non-numeric LOINC codes, including LOINC's own internal Part codes (prefixed "LP"). If you only need numeric, directly orderable/reportable LOINC codes, use `bgeresolve_loinc_numeric_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_loinc_2_83_en_6.4.1_3.4_1788715373419.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_loinc_2_83_en_6.4.1_3.4_1788715373419.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_loinc_2_83","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_loinc_2_83","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_loinc_2_83", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::104638-2:::62418-9:::50016-5:::6883-3:::4269-7:::2349-9:::54487-4:::LP7... | 0.0000:::0.1421:::0.1465:::0.1497:::0.1604:::0.1643:::0.1693:::0.1709:::0.1721::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose SD [Glucose standar... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::4548-4:::86910-7:::17856-6:::112870-1:::17855-8:::71875-9:::4549-2:::9... | 0.0678:::0.1064:::0.1390:::0.1409:::0.1531:::0.1654:::0.1654:::0.1668:::0.1808::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hgb A1c [Hemoglobin A1c... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::89044-2:::101655-9:::24321-2:::24320-4:::104076-5:::54233-2:::70219-1:... | 0.0000:::0.0534:::0.0710:::0.0733:::0.0872:::0.1042:::0.1393:::0.1453:::0.1473::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & albumi... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::81011-9:::28003-2:::23915-2:::9485-4:::32553-0:::35678-2:::34548-8:::16... | 0.0000:::0.1499:::0.1508:::0.1727:::0.1768:::0.1892:::0.1922:::0.1935:::0.1935::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::sodium intake [Sodium intake... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::32550-6:::75940-7:::86919-8:::28003-2:::35677-4:::6940-1:::90... | 0.0000:::0.1556:::0.1817:::0.1926:::0.1938:::0.1938:::0.2008:::0.2056:::0.2076::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Pota... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::47288-6:::74412-8:::51876-1:::1335-9:::LP71083-7:::11282-1::... | 0.0000:::0.1182:::0.1736:::0.1781:::0.1821:::0.1907:::0.1925:::0.2017:::0.2021::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_loinc_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|877.7 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-bgeresolve_loinc_augmented_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-bgeresolve_loinc_augmented_2_83_en.md
@@ -1,0 +1,265 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (augmented) (bge_base_en_v1_5_onnx embeddings)
+author: John Snow Labs
+name: bgeresolve_loinc_augmented_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `bge_base_en_v1_5_onnx` embeddings.
+
+Trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset).
+
+This model may also resolve to non-numeric LOINC codes, including LOINC's own internal Part, Answer, Panel, Survey, and other auxiliary/document codes (e.g. "LP...", "LA...", "PANEL...", "SURVEY..."). If you only need numeric, directly orderable/reportable LOINC codes, use `bgeresolve_loinc_numeric_augmented_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_loinc_augmented_2_83_en_6.4.1_3.4_1788723125501.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_loinc_augmented_2_83_en_6.4.1_3.4_1788723125501.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_loinc_augmented_2_83","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_loinc_augmented_2_83","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_loinc_augmented_2_83", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::54486-6:::104638-2:::62418-9:::50016-5:::LP385544-4:::2344-0:::6883-3::... | 0.0000:::0.1360:::0.1421:::0.1465:::0.1497:::0.1560:::0.1564:::0.1604:::0.1643::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose, Water [Glucose [Ma... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::4548-4:::86910-7:::17856-6:::112870-1:::17855-8:::71875-9:::4549-2:::9... | 0.0678:::0.1064:::0.1390:::0.1409:::0.1531:::0.1654:::0.1654:::0.1668:::0.1808::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hgb A1c [Hemoglobin A1c... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::89044-2:::LP265616-5:::LP386820-7:::101655-9:::24321-2:::LP434565-0:::... | 0.0000:::0.0534:::0.0545:::0.0652:::0.0710:::0.0733:::0.0751:::0.0872:::0.1042::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & albumi... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::9485-4:::81011-9:::28003-2:::13895-8:::LP386631-8:::12907-2:::LP386652-... | 0.0000:::0.1135:::0.1499:::0.1508:::0.1517:::0.1618:::0.1635:::0.1646:::0.1665::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::Sodium, Water [Sodium [Mass/... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::9482-1:::10322-6:::59733-6:::LP386601-1:::LP386623-5:::2821-7:::2824-1:... | 0.0000:::0.1425:::0.1556:::0.1598:::0.1612:::0.1667:::0.1764:::0.1780:::0.1784::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::Potassium, Water [Pota... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::47288-6:::74412-8:::11282-1:::51876-1:::1335-9:::LP71083-7::... | 0.0000:::0.1182:::0.1736:::0.1781:::0.1812:::0.1821:::0.1907:::0.1925:::0.2021::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_loinc_augmented_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|1.2 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-bgeresolve_loinc_numeric_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-bgeresolve_loinc_numeric_2_83_en.md
@@ -1,0 +1,265 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (bge_base_en_v1_5_onnx embeddings)
+author: John Snow Labs
+name: bgeresolve_loinc_numeric_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `bge_base_en_v1_5_onnx` embeddings.
+
+Trained on the official LOINC 2.83 dataset, scoped to numeric LOINC codes, without the inclusion of LOINC "Document Ontology" codes starting with the letter "L".
+
+If you also need LOINC's non-numeric auxiliary codes (e.g. Part codes prefixed "LP"), use `bgeresolve_loinc_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_loinc_numeric_2_83_en_6.4.1_3.4_1788727188077.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_loinc_numeric_2_83_en_6.4.1_3.4_1788727188077.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_loinc_numeric_2_83","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_loinc_numeric_2_83","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_loinc_numeric_2_83", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::104638-2:::62418-9:::50016-5:::6883-3:::4269-7:::2349-9:::54487-4:::816... | 0.0000:::0.1421:::0.1465:::0.1497:::0.1604:::0.1643:::0.1693:::0.1709:::0.1759::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose SD [Glucose standar... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::4548-4:::86910-7:::17856-6:::112870-1:::17855-8:::71875-9:::4549-2:::9... | 0.0678:::0.1064:::0.1390:::0.1409:::0.1531:::0.1654:::0.1654:::0.1668:::0.1808::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hgb A1c [Hemoglobin A1c... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::89044-2:::101655-9:::24321-2:::24320-4:::104076-5:::54233-2:::70219-1:... | 0.0000:::0.0534:::0.0710:::0.0733:::0.0872:::0.1042:::0.1393:::0.1453:::0.1473::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & albumi... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::81011-9:::28003-2:::23915-2:::9485-4:::32553-0:::35678-2:::34548-8:::16... | 0.0000:::0.1499:::0.1508:::0.1727:::0.1768:::0.1892:::0.1922:::0.1935:::0.1935::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::sodium intake [Sodium intake... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::32550-6:::75940-7:::86919-8:::28003-2:::35677-4:::6940-1:::90... | 0.0000:::0.1556:::0.1817:::0.1926:::0.1938:::0.1938:::0.2008:::0.2056:::0.2076::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Pota... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::47288-6:::74412-8:::51876-1:::1335-9:::11282-1:::789-8:::570... | 0.0000:::0.1182:::0.1736:::0.1781:::0.1821:::0.1907:::0.2017:::0.2021:::0.2065::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_loinc_numeric_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|825.7 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-bgeresolve_loinc_numeric_augmented_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-bgeresolve_loinc_numeric_augmented_2_83_en.md
@@ -1,0 +1,265 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (numeric, augmented) (bge_base_en_v1_5_onnx embeddings)
+author: John Snow Labs
+name: bgeresolve_loinc_numeric_augmented_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, bge]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `bge_base_en_v1_5_onnx` embeddings.
+
+Trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset), scoped to numeric LOINC codes, without the inclusion of LOINC's non-numeric Part, Answer, Panel, Survey, and other auxiliary/document codes.
+
+If you also need LOINC's non-numeric auxiliary codes, use `bgeresolve_loinc_augmented_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/bgeresolve_loinc_numeric_augmented_2_83_en_6.4.1_3.4_1788725402691.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/bgeresolve_loinc_numeric_augmented_2_83_en_6.4.1_3.4_1788725402691.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")
+
+resolver = SentenceEntityResolverModel.pretrained("bgeresolve_loinc_numeric_augmented_2_83","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BGEEmbeddings.pretrained("bge_base_en_v1_5_onnx", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("bge_embeddings")
+
+resolver = medical.SentenceEntityResolverModel.pretrained("bgeresolve_loinc_numeric_augmented_2_83","en","clinical/models")\
+    .setInputCols(["bge_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BGEEmbeddings
+    .pretrained("bge_base_en_v1_5_onnx", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("bge_embeddings")
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("bgeresolve_loinc_numeric_augmented_2_83", "en", "clinical/models")
+    .setInputCols(Array("bge_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::54486-6:::104638-2:::62418-9:::50016-5:::2344-0:::6883-3:::4269-7:::234... | 0.0000:::0.1360:::0.1421:::0.1465:::0.1497:::0.1564:::0.1604:::0.1643:::0.1693::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose, Water [Glucose [Ma... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::4548-4:::86910-7:::17856-6:::112870-1:::17855-8:::71875-9:::4549-2:::9... | 0.0678:::0.1064:::0.1390:::0.1409:::0.1531:::0.1654:::0.1654:::0.1668:::0.1808::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hgb A1c [Hemoglobin A1c... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::89044-2:::101655-9:::24321-2:::24320-4:::104076-5:::54233-2:::70219-1:... | 0.0000:::0.0534:::0.0710:::0.0733:::0.0872:::0.1042:::0.1393:::0.1453:::0.1473::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & albumi... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::9485-4:::81011-9:::28003-2:::13895-8:::12907-2:::2950-4:::23915-2:::569... | 0.0000:::0.1135:::0.1499:::0.1508:::0.1517:::0.1635:::0.1665:::0.1727:::0.1776::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::Sodium, Water [Sodium [Mass/... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::9482-1:::10322-6:::59733-6:::2821-7:::2824-1:::2825-8:::2828-2:::32550-... | 0.0000:::0.1425:::0.1556:::0.1598:::0.1764:::0.1780:::0.1784:::0.1802:::0.1817::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::Potassium, Water [Pota... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::47288-6:::74412-8:::11282-1:::51876-1:::1335-9:::789-8:::570... | 0.0000:::0.1182:::0.1736:::0.1781:::0.1812:::0.1821:::0.1907:::0.2021:::0.2065::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|bgeresolve_loinc_numeric_augmented_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[bge_embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|944.3 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-biolordresolve_loinc_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-biolordresolve_loinc_2_83_en.md
@@ -1,0 +1,268 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (mpnet_embeddings_biolord_2023_c embeddings)
+author: John Snow Labs
+name: biolordresolve_loinc_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `mpnet_embeddings_biolord_2023_c` embeddings.
+
+Trained on the official LOINC 2.83 dataset.
+
+This model may also resolve to non-numeric LOINC codes, including LOINC's own internal Part codes (prefixed "LP"). If you only need numeric, directly orderable/reportable LOINC codes, use `biolordresolve_loinc_numeric_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_loinc_2_83_en_6.4.1_3.4_1788714188493.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_loinc_2_83_en_6.4.1_3.4_1788714188493.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("biolord_embeddings")\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_loinc_2_83","en","clinical/models")\
+    .setInputCols(["biolord_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("biolord_embeddings")\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_loinc_2_83","en","clinical/models")\
+    .setInputCols(["biolord_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("biolord_embeddings")
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_loinc_2_83", "en", "clinical/models")
+    .setInputCols(Array("biolord_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::47621-8:::50016-5:::104638-2:::6883-3:::4269-7:::72648-9:::41104-1:::LP... | 0.0000:::0.1485:::0.1675:::0.1755:::0.1831:::0.2043:::0.2341:::0.2474:::0.2676::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose IV [Glucose.IV [Mas... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::4548-4:::51196-4:::4547-6:::112870-1:::96595-4:::17856-6:::74246-0:::6... | 0.0811:::0.1184:::0.1908:::0.2340:::0.2511:::0.2618:::0.2672:::0.2739:::0.2786::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hgb A1c [Hemoglobin A1c... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::24320-4:::24321-2:::24323-8:::24322-0:::89044-2:::101655-9:::LP146091-... | 0.0000:::0.0953:::0.1003:::0.1104:::0.1117:::0.1420:::0.1659:::0.2327:::0.2473::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic 1998 pan... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::LP31577-7:::23915-2:::24326-1:::19096-7:::75264-2:::81011-9:::23611-7::... | 0.0000:::0.1845:::0.2493:::0.3039:::0.3136:::0.3281:::0.3415:::0.3727:::0.3744::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::saline [Saline method]:::NaC... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::28003-2:::12812-4:::29349-8:::86919-8:::24326-1:::10322-6:::32552-2:::1... | 0.0000:::0.2364:::0.2837:::0.3011:::0.3013:::0.3081:::0.3169:::0.3174:::0.3188::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::sodium/potassium [Sodi... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::786-4:::33255-1:::11282-1:::112620-0:::74412-8:::777-3:::490... | 0.0000:::0.1648:::0.2574:::0.2604:::0.2720:::0.2844:::0.2986:::0.3003:::0.3213::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_loinc_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|878.2 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-biolordresolve_loinc_augmented_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-biolordresolve_loinc_augmented_2_83_en.md
@@ -1,0 +1,268 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (augmented) (mpnet_embeddings_biolord_2023_c embeddings)
+author: John Snow Labs
+name: biolordresolve_loinc_augmented_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `mpnet_embeddings_biolord_2023_c` embeddings.
+
+Trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset).
+
+This model may also resolve to non-numeric LOINC codes, including LOINC's own internal Part, Answer, Panel, Survey, and other auxiliary/document codes (e.g. "LP...", "LA...", "PANEL...", "SURVEY..."). If you only need numeric, directly orderable/reportable LOINC codes, use `biolordresolve_loinc_numeric_augmented_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_loinc_augmented_2_83_en_6.4.1_3.4_1788722318798.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_loinc_augmented_2_83_en_6.4.1_3.4_1788722318798.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("biolord_embeddings")\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_loinc_augmented_2_83","en","clinical/models")\
+    .setInputCols(["biolord_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("biolord_embeddings")\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_loinc_augmented_2_83","en","clinical/models")\
+    .setInputCols(["biolord_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("biolord_embeddings")
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_loinc_augmented_2_83", "en", "clinical/models")
+    .setInputCols(Array("biolord_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::47621-8:::50016-5:::104638-2:::6883-3:::2344-0:::LP89291-6:::4269-7:::3... | 0.0000:::0.1485:::0.1675:::0.1755:::0.1831:::0.1927:::0.1951:::0.2043:::0.2133::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose IV [Glucose.IV [Mas... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::4548-4:::51196-4:::4547-6:::112870-1:::96595-4:::17856-6:::74246-0:::6... | 0.0811:::0.1184:::0.1905:::0.2340:::0.2511:::0.2618:::0.2672:::0.2739:::0.2786::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hgb A1c [Hemoglobin A1c... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::24320-4:::24321-2:::24323-8:::24322-0:::LP265616-5:::89044-2:::101655-... | 0.0000:::0.0953:::0.1003:::0.1104:::0.1117:::0.1186:::0.1420:::0.1659:::0.1816::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic 1998 pan... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::2950-4:::32340-2:::LA24059-0:::23915-2:::9485-4:::2955-3:::2954-6:::152... | 0.0000:::0.1630:::0.1713:::0.1845:::0.2493:::0.2564:::0.2610:::0.2807:::0.2852::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::Sodium, Body fluid [Sodium [... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::2821-7:::32336-0:::59733-6:::9482-1:::2828-2:::28003-2:::2820-9:::50902... | 0.0000:::0.1396:::0.1573:::0.1962:::0.2145:::0.2289:::0.2364:::0.2468:::0.2561::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::Potassium, Body fluid ... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::11282-1:::LP7803-2:::786-4:::33255-1:::112620-0:::74412-8:::... | 0.0000:::0.1648:::0.1689:::0.2476:::0.2574:::0.2604:::0.2844:::0.2986:::0.3003::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_loinc_augmented_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|1.3 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-biolordresolve_loinc_numeric_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-biolordresolve_loinc_numeric_2_83_en.md
@@ -1,0 +1,268 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (mpnet_embeddings_biolord_2023_c embeddings)
+author: John Snow Labs
+name: biolordresolve_loinc_numeric_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `mpnet_embeddings_biolord_2023_c` embeddings.
+
+Trained on the official LOINC 2.83 dataset, scoped to numeric LOINC codes, without the inclusion of LOINC "Document Ontology" codes starting with the letter "L".
+
+If you also need LOINC's non-numeric auxiliary codes (e.g. Part codes prefixed "LP"), use `biolordresolve_loinc_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_loinc_numeric_2_83_en_6.4.1_3.4_1788726674224.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_loinc_numeric_2_83_en_6.4.1_3.4_1788726674224.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("biolord_embeddings")\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_loinc_numeric_2_83","en","clinical/models")\
+    .setInputCols(["biolord_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("biolord_embeddings")\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_loinc_numeric_2_83","en","clinical/models")\
+    .setInputCols(["biolord_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("biolord_embeddings")
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_loinc_numeric_2_83", "en", "clinical/models")
+    .setInputCols(Array("biolord_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::47621-8:::50016-5:::104638-2:::6883-3:::4269-7:::72648-9:::41104-1:::16... | 0.0000:::0.1485:::0.1675:::0.1755:::0.1831:::0.2043:::0.2341:::0.2474:::0.2686::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose IV [Glucose.IV [Mas... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::4548-4:::51196-4:::4547-6:::112870-1:::96595-4:::17856-6:::74246-0:::6... | 0.0811:::0.1184:::0.1908:::0.2340:::0.2511:::0.2618:::0.2672:::0.2739:::0.2786::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hgb A1c [Hemoglobin A1c... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::24320-4:::24321-2:::24323-8:::24322-0:::89044-2:::101655-9:::104076-5:... | 0.0000:::0.0953:::0.1003:::0.1104:::0.1117:::0.1420:::0.1659:::0.2473:::0.2514::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic 1998 pan... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::23915-2:::24326-1:::19096-7:::75264-2:::81011-9:::23611-7:::97779-3:::9... | 0.0000:::0.2493:::0.3039:::0.3136:::0.3281:::0.3415:::0.3727:::0.3744:::0.3769::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::NaCl [Osmotic fragility of R... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::28003-2:::12812-4:::29349-8:::86919-8:::24326-1:::10322-6:::32552-2:::1... | 0.0000:::0.2364:::0.2837:::0.3011:::0.3013:::0.3081:::0.3169:::0.3174:::0.3188::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::sodium/potassium [Sodi... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::786-4:::33255-1:::11282-1:::112620-0:::74412-8:::777-3:::490... | 0.0000:::0.1648:::0.2574:::0.2604:::0.2720:::0.2844:::0.2986:::0.3003:::0.3213::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_loinc_numeric_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|826.2 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-biolordresolve_loinc_numeric_augmented_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-biolordresolve_loinc_numeric_augmented_2_83_en.md
@@ -1,0 +1,268 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (numeric, augmented) (mpnet_embeddings_biolord_2023_c embeddings)
+author: John Snow Labs
+name: biolordresolve_loinc_numeric_augmented_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, biolord]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `mpnet_embeddings_biolord_2023_c` embeddings.
+
+Trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset), scoped to numeric LOINC codes, without the inclusion of LOINC's non-numeric Part, Answer, Panel, Survey, and other auxiliary/document codes.
+
+If you also need LOINC's non-numeric auxiliary codes, use `biolordresolve_loinc_augmented_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/biolordresolve_loinc_numeric_augmented_2_83_en_6.4.1_3.4_1788724768311.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/biolordresolve_loinc_numeric_augmented_2_83_en_6.4.1_3.4_1788724768311.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("biolord_embeddings")\
+    .setBatchSize(1)
+
+resolver = SentenceEntityResolverModel.pretrained("biolordresolve_loinc_numeric_augmented_2_83","en","clinical/models")\
+    .setInputCols(["biolord_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.MPNetEmbeddings.pretrained("mpnet_embeddings_biolord_2023_c", "en")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("biolord_embeddings")\
+    .setBatchSize(1)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("biolordresolve_loinc_numeric_augmented_2_83","en","clinical/models")\
+    .setInputCols(["biolord_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = MPNetEmbeddings
+    .pretrained("mpnet_embeddings_biolord_2023_c", "en")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("biolord_embeddings")
+    .setBatchSize(1)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("biolordresolve_loinc_numeric_augmented_2_83", "en", "clinical/models")
+    .setInputCols(Array("biolord_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::47621-8:::50016-5:::104638-2:::6883-3:::2344-0:::4269-7:::32318-8:::544... | 0.0000:::0.1485:::0.1675:::0.1755:::0.1831:::0.1927:::0.2043:::0.2133:::0.2145::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose IV [Glucose.IV [Mas... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::4548-4:::51196-4:::4547-6:::112870-1:::96595-4:::17856-6:::74246-0:::6... | 0.0811:::0.1184:::0.1905:::0.2340:::0.2511:::0.2618:::0.2672:::0.2739:::0.2786::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hgb A1c [Hemoglobin A1c... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::24320-4:::24321-2:::24323-8:::24322-0:::89044-2:::101655-9:::88843-8::... | 0.0000:::0.0953:::0.1003:::0.1104:::0.1117:::0.1420:::0.1659:::0.2157:::0.2473      | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic 1998 pan... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::2950-4:::32340-2:::23915-2:::9485-4:::2955-3:::2954-6:::15207-4:::2949-... | 0.0000:::0.1630:::0.1713:::0.2493:::0.2564:::0.2610:::0.2807:::0.2852:::0.2984::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::Sodium, Body fluid [Sodium [... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::2821-7:::32336-0:::59733-6:::9482-1:::2828-2:::28003-2:::2820-9:::50902... | 0.0000:::0.1396:::0.1573:::0.1962:::0.2145:::0.2289:::0.2364:::0.2468:::0.2561::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::Potassium, Body fluid ... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::11282-1:::786-4:::33255-1:::112620-0:::74412-8:::777-3:::669... | 0.0000:::0.1648:::0.1689:::0.2574:::0.2604:::0.2844:::0.2986:::0.3003:::0.3108::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|biolordresolve_loinc_numeric_augmented_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|944.9 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-loinc_mapper_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-loinc_mapper_2_83_en.md
@@ -1,0 +1,235 @@
+---
+layout: model
+title: Mapping Entities with Corresponding LOINC Codes
+author: John Snow Labs
+name: loinc_mapper_2_83
+date: 2026-09-06
+tags: [en, chunk_mapper, licensed, clinical, loinc]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps entities extracted from text to their corresponding LOINC (Logical Observation Identifiers Names and Codes) codes.
+
+It performs a direct lookup against the training dictionary, providing fast, exact-match code mapping.
+
+Trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset).
+
+This model may also map to non-numeric LOINC codes, including LOINC's own internal Part, Answer, Panel, Survey, and other auxiliary/document codes (e.g. "LP...", "LA...", "PANEL...", "SURVEY..."). If you only need numeric, directly orderable/reportable LOINC codes, use `loinc_numeric_mapper_2_83` instead.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/loinc_mapper_2_83_en_6.4.1_3.4_1788729009249.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/loinc_mapper_2_83_en_6.4.1_3.4_1788729009249.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+loinc_mapper = ChunkMapperModel.pretrained("loinc_mapper_2_83", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["loinc_code"])
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, loinc_mapper\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+loinc_mapper = medical.ChunkMapperModel.pretrained("loinc_mapper_2_83", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["loinc_code"])
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, loinc_mapper\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val loincMapper = ChunkMapperModel.pretrained("loinc_mapper_2_83", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("loinc_code"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, loincMapper
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | loinc_code   | all_k_resolutions               |
+|:----------------------|:-------------|:--------------------------------|
+| glucose               | 2345-7       | 2345-7:::LP14635-4:::LP435977-6 |
+| hemoglobin A1c        | 41995-2      | 41995-2:::LP16413-4             |
+| basic metabolic panel | 51990-0      | 51990-0:::LP67153-4             |
+| sodium                | 2951-2       | 2951-2:::LP15099-2              |
+| potassium             | 2823-3       | 2823-3:::LP15098-4              |
+| complete blood count  | 24317-0      | 24317-0:::24358-4:::24359-2     |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|loinc_mapper_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|16.6 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-loinc_numeric_mapper_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-loinc_numeric_mapper_2_83_en.md
@@ -1,0 +1,235 @@
+---
+layout: model
+title: Mapping Entities with Corresponding LOINC Codes
+author: John Snow Labs
+name: loinc_numeric_mapper_2_83
+date: 2026-09-06
+tags: [en, chunk_mapper, licensed, clinical, loinc]
+task: Chunk Mapping
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: ChunkMapperModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps entities extracted from text to their corresponding LOINC (Logical Observation Identifiers Names and Codes) codes.
+
+It performs a direct lookup against the training dictionary, providing fast, exact-match code mapping.
+
+Trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset), scoped to numeric LOINC codes, without the inclusion of LOINC's non-numeric Part, Answer, Panel, Survey, and other auxiliary/document codes.
+
+If you also need LOINC's non-numeric auxiliary codes, use `loinc_mapper_2_83` instead.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/06.0.Chunk_Mapping.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/loinc_numeric_mapper_2_83_en_6.4.1_3.4_1788729639223.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/loinc_numeric_mapper_2_83_en_6.4.1_3.4_1788729639223.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+loinc_mapper = ChunkMapperModel.pretrained("loinc_numeric_mapper_2_83", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["loinc_code"])
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, loinc_mapper\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+loinc_mapper = medical.ChunkMapperModel.pretrained("loinc_numeric_mapper_2_83", "en", "clinical/models")\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("mappings")\
+    .setRels(["loinc_code"])
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, loinc_mapper\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val loincMapper = ChunkMapperModel.pretrained("loinc_numeric_mapper_2_83", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("mappings")
+    .setRels(Array("loinc_code"))
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, loincMapper
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | loinc_code   | all_k_resolutions           |
+|:----------------------|:-------------|:----------------------------|
+| glucose               | 2345-7       | 2345-7:::                   |
+| hemoglobin A1c        | 41995-2      | 41995-2:::                  |
+| basic metabolic panel | 51990-0      | 51990-0:::                  |
+| sodium                | 2951-2       | 2951-2:::                   |
+| potassium             | 2823-3       | 2823-3:::                   |
+| complete blood count  | 24317-0      | 24317-0:::24358-4:::24359-2 |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|loinc_numeric_mapper_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[ner_chunk]|
+|Output Labels:|[mappings]|
+|Language:|en|
+|Size:|12.8 MB|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-sbiobertresolve_loinc_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-sbiobertresolve_loinc_2_83_en.md
@@ -1,0 +1,268 @@
+---
+layout: model
+title: Sentence Entity Resolver for Logical Observation Identifiers Names and Codes (LOINC) (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_loinc_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted medical entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings.
+
+Trained on the official LOINC 2.83 dataset.
+
+This model may also resolve to non-numeric LOINC codes, including LOINC's own internal Part codes (prefixed "LP"). If you only need numeric, directly orderable/reportable LOINC codes, use `sbiobertresolve_loinc_numeric_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_2_83_en_6.4.1_3.4_1788704583426.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_2_83_en_6.4.1_3.4_1788704583426.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_loinc_2_83","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_loinc_2_83","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_loinc_2_83", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::74790-7:::51419-0:::81637-1:::47621-8:::104638-2:::50016-5:::72648-9:::... | 0.0000:::0.0666:::0.0713:::0.0763:::0.0738:::0.0824:::0.0880:::0.0952:::0.1009::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose HBT [Glucose challe... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::LP16412-6:::43150-2:::4548-4:::10486-9:::21687-9:::112870-1:::LP16430-... | 0.0227:::0.0500:::0.0727:::0.0987:::0.1004:::0.1010:::0.1161:::0.1193:::0.1237::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::hemoglobin a1 [Hemoglob... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::101655-9:::89044-2:::9350-0:::50042-1:::79531-0:::43147-8:::24321-2:::... | 0.0000:::0.1401:::0.1417:::0.1533:::0.1772:::0.1913:::0.2036:::0.2081:::0.2056::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & hemato... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::81011-9:::9086-0:::16527-4:::9087-8:::2957-9:::43423-3:::87451-1:::5091... | 0.0000:::0.0820:::0.0910:::0.0981:::0.1114:::0.1200:::0.1244:::0.1325:::0.1336::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::sodium intake [Sodium intake... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::9073-8:::28003-2:::2830-8:::59733-6:::9074-6:::25506-7:::8745... | 0.0000:::0.0583:::0.0882:::0.0966:::0.1101:::0.1208:::0.1180:::0.1411:::0.1451::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Pota... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::74412-8:::47288-6:::1335-9:::789-8:::51876-1:::LP71083-7:::7... | 0.0000:::0.1068:::0.1309:::0.1352:::0.1489:::0.1658:::0.1671:::0.1693:::0.1761::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_loinc_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|876.6 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-sbiobertresolve_loinc_augmented_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-sbiobertresolve_loinc_augmented_2_83_en.md
@@ -1,0 +1,266 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_loinc_augmented_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings. It is trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset).
+
+This model may also resolve to non-numeric LOINC codes, including LOINC's own internal Part, Answer, Panel, Survey, and other auxiliary/document codes (e.g. "LP...", "LA...", "PANEL...", "SURVEY..."). If you only need numeric, directly orderable/reportable LOINC codes, use `sbiobertresolve_loinc_numeric_augmented_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_augmented_2_83_en_6.4.1_3.4_1788715958482.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_augmented_2_83_en_6.4.1_3.4_1788715958482.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_loinc_augmented_2_83","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_loinc_augmented_2_83","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_loinc_augmented_2_83", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::74790-7:::51419-0:::81637-1:::47621-8:::32318-8:::104638-2:::50016-5:::... | 0.0000:::0.0666:::0.0713:::0.0763:::0.0738:::0.0781:::0.0824:::0.0880:::0.0949::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose HBT [Glucose challe... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::LP16412-6:::43150-2:::4548-4:::10486-9:::21687-9:::112870-1:::LP16430-... | 0.0227:::0.0500:::0.0727:::0.0987:::0.1004:::0.1010:::0.1161:::0.1193:::0.1237::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::hemoglobin a1 [Hemoglob... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::101655-9:::89044-2:::LP434565-0:::LP265616-5:::9350-0:::50042-1:::7953... | 0.0000:::0.1401:::0.1417:::0.1499:::0.1503:::0.1533:::0.1772:::0.1913:::0.2036::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & hemato... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::32340-2:::50912-5:::81011-9:::9086-0:::16527-4:::2950-4:::9087-8:::2954... | 0.0000:::0.0504:::0.0815:::0.0820:::0.0910:::0.0981:::0.1062:::0.1114:::0.1137::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::Sodium, Specimen [Sodium [Mo... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::32336-0:::59733-6:::9073-8:::28003-2:::2821-7:::50902-6:::283... | 0.0000:::0.0583:::0.0662:::0.0821:::0.0882:::0.0966:::0.1032:::0.1048:::0.1101::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Pota... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::74412-8:::47288-6:::1335-9:::789-8:::51876-1:::LP71083-7:::7... | 0.0000:::0.1068:::0.1309:::0.1352:::0.1489:::0.1658:::0.1671:::0.1693:::0.1761::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_loinc_augmented_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|1.2 GB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-sbiobertresolve_loinc_numeric_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-sbiobertresolve_loinc_numeric_2_83_en.md
@@ -1,0 +1,268 @@
+---
+layout: model
+title: Sentence Entity Resolver for Logical Observation Identifiers Names and Codes (LOINC) (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_loinc_numeric_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted medical entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings.
+
+Trained on the official LOINC 2.83 dataset, scoped to numeric LOINC codes, without the inclusion of LOINC "Document Ontology" codes starting with the letter "L".
+
+If you also need LOINC's non-numeric auxiliary codes (e.g. Part codes prefixed "LP"), use `sbiobertresolve_loinc_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_numeric_2_83_en_6.4.1_3.4_1788726042347.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_numeric_2_83_en_6.4.1_3.4_1788726042347.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_loinc_numeric_2_83","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_loinc_numeric_2_83","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_loinc_numeric_2_83", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::74790-7:::51419-0:::81637-1:::47621-8:::104638-2:::50016-5:::72648-9:::... | 0.0000:::0.0666:::0.0713:::0.0763:::0.0738:::0.0824:::0.0880:::0.0952:::0.1009::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose HBT [Glucose challe... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::43150-2:::4548-4:::10486-9:::21687-9:::112870-1:::51196-4:::10346-5:::... | 0.0227:::0.0727:::0.0987:::0.1004:::0.1010:::0.1161:::0.1237:::0.1311:::0.1383::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hemoglobin A1c measurem... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::101655-9:::89044-2:::9350-0:::50042-1:::79531-0:::43147-8:::24321-2:::... | 0.0000:::0.1401:::0.1417:::0.1533:::0.1772:::0.1913:::0.2036:::0.2081:::0.2056::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & hemato... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::81011-9:::9086-0:::16527-4:::9087-8:::2957-9:::43423-3:::87451-1:::5091... | 0.0000:::0.0820:::0.0910:::0.0981:::0.1114:::0.1200:::0.1244:::0.1325:::0.1336::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::sodium intake [Sodium intake... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::9073-8:::28003-2:::2830-8:::59733-6:::9074-6:::25506-7:::8745... | 0.0000:::0.0583:::0.0882:::0.0966:::0.1101:::0.1208:::0.1180:::0.1411:::0.1451::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Pota... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::74412-8:::47288-6:::1335-9:::789-8:::51876-1:::786-4:::777-3... | 0.0000:::0.1068:::0.1309:::0.1352:::0.1489:::0.1658:::0.1671:::0.1761:::0.1936::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_loinc_numeric_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|824.7 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-06-sbiobertresolve_loinc_numeric_augmented_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-06-sbiobertresolve_loinc_numeric_augmented_2_83_en.md
@@ -1,0 +1,266 @@
+---
+layout: model
+title: Sentence Entity Resolver for LOINC (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_loinc_numeric_augmented_2_83
+date: 2026-09-06
+tags: [en, entity_resolution, licensed, clinical, loinc, sbiobert]
+task: Entity Resolution
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: SentenceEntityResolverModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This model maps extracted clinical NER entities to Logical Observation Identifiers Names and Codes (LOINC) codes using `sbiobert_base_cased_mli_onnx` Sentence Bert Embeddings. It is trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset), scoped to numeric LOINC codes, without the inclusion of LOINC's non-numeric Part, Answer, Panel, Survey, and other auxiliary/document codes.
+
+If you also need LOINC's non-numeric auxiliary codes, use `sbiobertresolve_loinc_augmented_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/3.Clinical_Entity_Resolvers.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_numeric_augmented_2_83_en_6.4.1_3.4_1788724011444.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_numeric_augmented_2_83_en_6.4.1_3.4_1788724011444.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+documentAssembler = DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = MedicalNerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = MedicalNerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = SentenceEntityResolverModel.pretrained("sbiobertresolve_loinc_numeric_augmented_2_83","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+
+{:.jsl-block}
+```python
+documentAssembler = nlp.DocumentAssembler()\
+    .setInputCol("text")\
+    .setOutputCol("document")
+
+sentenceDetectorDL = nlp.SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")\
+    .setInputCols(["document"])\
+    .setOutputCol("sentence")
+
+tokenizer = nlp.Tokenizer()\
+    .setInputCols(["sentence"])\
+    .setOutputCol("token")
+
+word_embeddings = nlp.WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models")\
+    .setInputCols(["sentence","token"])\
+    .setOutputCol("embeddings")
+
+ner_radiology = medical.NerModel.pretrained("ner_radiology","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_radiology")
+
+ner_converter_radiology = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_radiology"])\
+    .setOutputCol("ner_chunk_radiology")\
+    .setWhiteList(["Test"])
+
+ner_jsl = medical.NerModel.pretrained("ner_jsl","en","clinical/models")\
+    .setInputCols(["sentence","token","embeddings"])\
+    .setOutputCol("ner_jsl")
+
+ner_converter_jsl = medical.NerConverterInternal()\
+    .setInputCols(["sentence","token","ner_jsl"])\
+    .setOutputCol("ner_chunk_jsl")\
+    .setWhiteList(["Test"])
+
+chunk_merger = medical.ChunkMergeApproach()\
+    .setInputCols("ner_chunk_jsl", "ner_chunk_radiology")\
+    .setOutputCol("ner_chunk")
+
+chunk2doc = nlp.Chunk2Doc()\
+    .setInputCols(["ner_chunk"])\
+    .setOutputCol("ner_chunk_doc")
+
+embedder = nlp.BertSentenceEmbeddings.pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")\
+    .setInputCols(["ner_chunk_doc"])\
+    .setOutputCol("sbert_embeddings")\
+    .setCaseSensitive(False)
+
+resolver = medical.SentenceEntityResolverModel.pretrained("sbiobertresolve_loinc_numeric_augmented_2_83","en","clinical/models")\
+    .setInputCols(["sbert_embeddings"])\
+    .setOutputCol("resolution")\
+    .setDistanceFunction("EUCLIDEAN")
+
+pipeline = nlp.Pipeline(stages=[\
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,\
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,\
+    chunk_merger, chunk2doc,\
+    embedder, resolver\
+])
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+```
+```scala
+
+val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+val sentenceDetectorDL = SentenceDetectorDLModel
+    .pretrained("sentence_detector_dl_healthcare", "en", "clinical/models")
+    .setInputCols(Array("document"))
+    .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+    .setInputCols("sentence")
+    .setOutputCol("token")
+
+val word_embeddings = WordEmbeddingsModel
+    .pretrained("embeddings_clinical", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token"))
+    .setOutputCol("embeddings")
+
+val ner_radiology = MedicalNerModel
+    .pretrained("ner_radiology", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_radiology")
+
+val ner_converter_radiology = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_radiology"))
+    .setOutputCol("ner_chunk_radiology")
+    .setWhiteList(Array("Test"))
+
+val ner_jsl = MedicalNerModel
+    .pretrained("ner_jsl", "en", "clinical/models")
+    .setInputCols(Array("sentence", "token", "embeddings"))
+    .setOutputCol("ner_jsl")
+
+val ner_converter_jsl = new NerConverterInternal()
+    .setInputCols(Array("sentence", "token", "ner_jsl"))
+    .setOutputCol("ner_chunk_jsl")
+    .setWhiteList(Array("Test"))
+
+val chunk_merger = new ChunkMergeApproach()
+    .setInputCols(Array("ner_chunk_jsl", "ner_chunk_radiology"))
+    .setOutputCol("ner_chunk")
+
+val chunk2doc = new Chunk2Doc()
+    .setInputCols(Array("ner_chunk"))
+    .setOutputCol("ner_chunk_doc")
+
+val embedder = BertSentenceEmbeddings
+    .pretrained("sbiobert_base_cased_mli_onnx", "en", "clinical/models")
+    .setInputCols(Array("ner_chunk_doc"))
+    .setOutputCol("sbert_embeddings")
+    .setCaseSensitive(false)
+
+val resolver = SentenceEntityResolverModel
+    .pretrained("sbiobertresolve_loinc_numeric_augmented_2_83", "en", "clinical/models")
+    .setInputCols(Array("sbert_embeddings"))
+    .setOutputCol("resolution")
+    .setDistanceFunction("EUCLIDEAN")
+
+val pipeline = new Pipeline().setStages(Array(
+    documentAssembler, sentenceDetectorDL, tokenizer, word_embeddings,
+    ner_radiology, ner_converter_radiology, ner_jsl, ner_converter_jsl,
+    chunk_merger, chunk2doc,
+    embedder, resolver
+))
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val res = pipeline.fit(data).transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| ner_chunk             | entity   | LOINC Code   | Resolution                                                      | all_k_results                                                                       | all_k_cosine_distances                                                              | all_k_resolutions                                                                   |
+|:----------------------|:---------|:-------------|:----------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| glucose               | Test     | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::74790-7:::51419-0:::81637-1:::47621-8:::32318-8:::104638-2:::50016-5:::... | 0.0000:::0.0666:::0.0713:::0.0763:::0.0738:::0.0781:::0.0824:::0.0880:::0.0952::... | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose HBT [Glucose challe... |
+| hemoglobin A1c levels | Test     | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::43150-2:::4548-4:::10486-9:::21687-9:::112870-1:::51196-4:::4593-0:::1... | 0.0227:::0.0727:::0.0987:::0.1004:::0.1010:::0.1161:::0.1237:::0.1290:::0.1311::... | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hemoglobin A1c measurem... |
+| basic metabolic panel | Test     | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::101655-9:::89044-2:::9350-0:::50042-1:::79531-0:::43147-8:::24321-2:::... | 0.0000:::0.1401:::0.1417:::0.1533:::0.1772:::0.1913:::0.2036:::0.2081:::0.2056::... | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & hemato... |
+| sodium                | Test     | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::32340-2:::50912-5:::81011-9:::9086-0:::16527-4:::2950-4:::9087-8:::2954... | 0.0000:::0.0504:::0.0815:::0.0820:::0.0910:::0.0981:::0.1062:::0.1114:::0.1137::... | sodium [Sodium [Moles/volume] in Serum or Plasma]:::Sodium, Specimen [Sodium [Mo... |
+| potassium             | Test     | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::32336-0:::59733-6:::9073-8:::28003-2:::2821-7:::50902-6:::283... | 0.0000:::0.0583:::0.0662:::0.0821:::0.0882:::0.0966:::0.1032:::0.1048:::0.1101::... | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Pota... |
+| complete blood count  | Test     | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::74412-8:::47288-6:::1335-9:::789-8:::51876-1:::786-4:::777-3... | 0.0000:::0.1068:::0.1309:::0.1352:::0.1489:::0.1658:::0.1671:::0.1761:::0.1936::... | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood... |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_loinc_numeric_augmented_2_83|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Input Labels:|[sbert_embeddings]|
+|Output Labels:|[loinc_code]|
+|Language:|en|
+|Size:|943.2 MB|
+|Case sensitive:|false|

--- a/docs/_posts/ozgurcaglayan1981/2026-09-07-sbiobertresolve_loinc_augmented_pipeline_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-07-sbiobertresolve_loinc_augmented_pipeline_2_83_en.md
@@ -1,0 +1,112 @@
+---
+layout: model
+title: Pipeline for Logical Observation Identifiers Names and Codes (LOINC) (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_loinc_augmented_pipeline_2_83
+date: 2026-09-07
+tags: [en, entity_resolution, licensed, clinical, loinc, pipeline, sbiobert]
+task: [Entity Resolution, Pipeline Healthcare]
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: PipelineModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This pipeline extracts `Test` entities from clinical texts and maps them to their corresponding Logical Observation Identifiers Names and Codes (LOINC) codes using `sbiobert_base_cased_mli` Sentence Bert Embeddings. It is trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset).
+
+This pipeline may also resolve to non-numeric LOINC codes, including LOINC's own internal Part, Answer, Panel, Survey, and other auxiliary/document codes (e.g. "LP...", "LA...", "PANEL...", "SURVEY..."). If you only need numeric, directly orderable/reportable LOINC codes, use `sbiobertresolve_loinc_numeric_augmented_pipeline_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/07.0.Pretrained_Clinical_Pipelines.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_augmented_pipeline_2_83_en_6.4.1_3.4_1788739283616.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_augmented_pipeline_2_83_en_6.4.1_3.4_1788739283616.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+from sparknlp.pretrained import PretrainedPipeline
+
+loinc_pipeline = PretrainedPipeline("sbiobertresolve_loinc_augmented_pipeline_2_83", "en", "clinical/models")
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = loinc_pipeline.transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+from johnsnowlabs import nlp, medical
+
+loinc_pipeline = nlp.PretrainedPipeline("sbiobertresolve_loinc_augmented_pipeline_2_83", "en", "clinical/models")
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = loinc_pipeline.transform(data)
+
+```
+```scala
+
+import com.johnsnowlabs.nlp.pretrained.PretrainedPipeline
+
+val loinc_pipeline = PretrainedPipeline("sbiobertresolve_loinc_augmented_pipeline_2_83", "en", "clinical/models")
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val result = loinc_pipeline.transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| chunk                 | label   | loinc_code   | resolution                                                      | all_codes                                                                                                                                                                                                                 | all_resolutions                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+|:----------------------|:--------|:-------------|:----------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| glucose               | Test    | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::74790-7:::51419-0:::81637-1:::47621-8:::32318-8:::104638-2:::50016-5:::LA19766-7:::72648-9:::27353-2:::6248-9:::41653-7:::LP69206-8:::4269-7:::95720-9:::41896-2:::26682-5:::50667-5:::97506-0                   | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose HBT [Glucose challenge (hydrogen breath test) panel - Exhaled gas]:::Glucose cor [Sodium [Moles/volume] corrected for glucose in Serum or Plasma]:::Glucose correlation [Glucose meter to reference method correlation [Ratio] in Serum, Plasma or Blood by calculation]:::glucose.iv [Glucose.IV [Mass] of Dose]:::Glucose, Specimen [Glucose [Moles/volume] in Specimen]:::Glucose SD [Glucose standard deviation/Glucose mean in Reporting Period Interstitial fluid by calculation]:::sugar [Sugar [Type] of Dose]:::Glucose monitor [Glucose monitor]:::glucose gradient [Glucose in serum - glucose in synovial fluid [Molar concentration difference]]:::Glucose mean value [Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin]:::Gly [Soybean IgE Ab [Units/volume] in Serum]:::Glucomtr [Glucose [Mass/volume] in Capillary blood by Glucometer]:::glucose csf [Glucose in CSF]:::glucose.po [Glucose.PO [Mass] of Dose]:::GlyR [Glycine receptor Ab [Titer] in Serum or Plasma by Immunoassay]:::Glucose Mtr Dev [Type of Glucose meter device]:::glycolate [Glycolate [Presence] in Urine]:::glucose tolerance [Glucose tolerance [Interpretation] in Serum or Plasma Narrative]:::Glucose management indicator [Glucose management indicator]                                                                                                                                                                                                                                      |
+| hemoglobin A1c levels | Test    | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::LP16412-6:::43150-2:::4548-4:::10486-9:::21687-9:::112870-1:::LP16430-8:::51196-4:::4593-0:::LP241878-0:::10346-5:::50319-3:::17871-5:::LP94632-4:::50385-4:::6864-3:::72914-5:::LP94633-2:::14563-1            | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::hemoglobin a1 [Hemoglobin A1]:::Hemoglobin A1c measurement device panel [Hemoglobin A1c measurement device panel]:::hemoglobin a1c/hemoglobin.total [Hemoglobin A1c/Hemoglobin.total in Blood]:::hemoglobin ag [Hemoglobin Ag [Presence] in Tissue by Immune stain]:::Hemoglobin, alpha 1 [HBA1 gene mutations found [Identifier] in Blood or Tissue by Targeted gene mutation analysis Nominal]:::hemoglobin a1c & estimated average glucose panel [Hemoglobin A1c and estimated average glucose panel - Blood]:::hemoglobin f1 [Hemoglobin F1]:::hemoglobin a1/hemoglobin.total [Hemoglobin A1/Hemoglobin.total in Blood by Electrophoresis]:::Hemoglobin I, Blood [Hemoglobin I [Presence] in Blood by Electrophoresis acid (pH 6.3)]:::AMPAR 1 Ab [AMPAR 1 Ab]:::hemoglobin a [Hemoglobin A [Units/volume] in Blood by Electrophoresis]:::hbme-1 ag [HBME-1 Ag [Presence] in Tissue by Immune stain]:::hemoglobin h [Hemoglobin H [Presence] in Blood by Heat denaturation]:::hemoglobin d+g [Hemoglobin D+G]:::A1 Microglob [Alpha-1-Microglobulin.placental [Presence] in Vaginal fluid]:::hemoglobin s [Hemoglobin S [Presence] in Blood by Solubility test]:::hna 1c ab [HNA 1c Ab [Presence] in Serum by Immunoassay]:::hemoglobin n+i [Hemoglobin N+I]:::hemoglobin^1st specimen [Hemoglobin [Presence] in Stool from gastrointestinal --1st specimen]                                                                                                                                                              |
+| basic metabolic panel | Test    | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::101655-9:::89044-2:::LP434565-0:::LP265616-5:::9350-0:::50042-1:::79531-0:::43147-8:::LP386820-7:::LP438405-5:::24321-2:::LA25424-5:::79529-4:::104076-5:::79530-2:::112034-4:::81578-7                         | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & hematocrit panel [Basic metabolic and hematocrit panel - Blood]:::basic metabolic & albumin panel [Basic metabolic and albumin panel - Serum or Plasma]:::Basic metabolic and hematocrit panel [Basic metabolic and hematocrit panel]:::Basic metabolic and albumin panel [Basic metabolic and albumin panel]:::Metabolic screen [Sulfhydryls [Presence] in Urine]:::Basal metabolic rate index [Basal metabolic rate index]:::basic mobility items [Basic mobility items number [Activity Measure for Post-Acute Care]]:::Metabolism measurement device panel [Metabolism measurement device panel]:::Basic metabolic panel | Blood | Chemistry Panels [Basic metabolic panel | Blood | Chemistry Panels]:::Basic metabolic with hemoglobin and hematocrit panel [Basic metabolic with hemoglobin and hematocrit panel]:::basic metabolic 2000 panel [Basic metabolic 2000 panel - Serum or Plasma]:::EMT - Basic [EMT - Basic]:::basic mobility score [Basic mobility score [AM-PAC]]:::basic metabolic & hemoglobin & hematocrit panel [Basic metabolic with hemoglobin and hematocrit panel - Blood]:::Basic mobility score SE [Basic mobility score standard error [AM-PAC]]:::Basic information [Basic information]:::PT Brain metabolic [PT Brain metabolic]                                                                                                                                                                                                                                          |
+| sodium                | Test    | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::32340-2:::50912-5:::81011-9:::9086-0:::16527-4:::2950-4:::9087-8:::2954-6:::9485-4:::2957-9:::43423-3:::LA33992-1:::87451-1:::2955-3:::87452-9:::56979-8:::14055-8:::17796-4:::2948-8:::28003-2                  | sodium [Sodium [Moles/volume] in Serum or Plasma]:::Sodium, Specimen [Sodium [Moles/volume] in Specimen]:::Sodium, Hair [Sodium [Moles/mass] in Hair]:::sodium intake [Sodium intake 24 hour Estimated]:::Sodium intake Est [Sodium intake Estimated]:::calcium/sodium [Calcium/Sodium [Mass Ratio] in Serum or Plasma]:::Sodium, Body fluid [Sodium [Moles/volume] in Body fluid]:::Sodium intake Measured [Sodium intake Measured]:::Sodium, Sweat [Sodium [Moles/volume] in Sweat]:::Sodium, Water [Sodium [Mass/volume] in Water]:::sodium renal clearance [Sodium renal clearance in 24 hour Urine and Serum or Plasma]:::sodium urate [Sodium urate [Saturation Fraction] in 24 hour Urine]:::sodium citrate [sodium citrate]:::Sodium [Mass/volume] in Specimen [Sodium [Mass/volume] in Specimen]:::Sodium, Urine [Sodium [Moles/volume] in Urine]:::Sodium [Mass/mass] in Specimen [Sodium [Mass/mass] in Specimen]:::Sodium, Saliva [Sodium [Moles/volume] in Saliva (oral fluid)]:::Sodium Stl-sCnt [Sodium [Moles/mass] in Stool]:::Sodium, Hyperal solution [Sodium [Moles/volume] in Hyperal solution]:::Sodium, Spinal fluid [Sodium [Moles/volume] in Cerebral spinal fluid]:::sodium/potassium [Sodium/Potassium [Molar ratio] in Serum or Plasma]                                                                                                                                                                                                                                                                                                                    |
+| potassium             | Test    | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::32336-0:::59733-6:::9073-8:::28003-2:::2821-7:::50902-6:::2830-8:::9074-6:::LA33991-3:::25506-7:::9482-1:::87455-2:::2819-1:::49788-3:::2827-4:::2828-2:::59010-9                                      | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Potassium intake 24 hour]:::Potassium, Specimen [Potassium [Moles/volume] in Specimen]:::Potassium, Tissue [Potassium [Mass/mass] in Tissue]:::Potassium intake Est [Potassium intake Estimated]:::sodium/potassium [Sodium/Potassium [Molar ratio] in Serum or Plasma]:::Potassium, Body fluid [Potassium [Moles/volume] in Body fluid]:::Potassium, Hair [Potassium [Moles/mass] in Hair]:::potassium renal clearance [Potassium renal clearance in 24 hour Urine and Serum or Plasma]:::Potassium intake Measured [Potassium intake Measured]:::potassium citrate [potassium citrate]:::Potassium Stl-sCnt [Potassium [Moles/mass] in Stool]:::Potassium, Water [Potassium [Mass/volume] in Water]:::Potassium Spec-mCnt [Potassium [Mass/mass] in Specimen]:::Potassium, Spinal fluid [Potassium [Moles/volume] in Cerebral spinal fluid]:::Potassium Amn-sCnc [Potassium [Moles/volume] in Amniotic fluid]:::Potassium, Sweat [Potassium [Moles/volume] in Sweat]:::Potassium, Urine [Potassium [Moles/volume] in Urine]:::fractional excretion of potassium [Fractional excretion of potassium [Ratio] in Urine and Serum or Plasma collected for unspecified duration]                                                                                                                                                                                                                                                                                                                              |
+| complete blood count  | Test    | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::74412-8:::47288-6:::1335-9:::789-8:::51876-1:::LP71083-7:::786-4:::LA28366-5:::LP7803-2:::LP14154-6:::777-3:::39227-4:::41986-1:::111539-3:::55781-9:::57022-6:::57021-8:::51637-7:::4544-3:::53963-5 | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood count panel [CBC panel - Blood by Automated count]:::complete blood count w differential panel [CBC W Differential panel - Cord blood]:::complete blood count wo differential panel [CBC WO Differential panel - Cord blood]:::whole blood given [Whole blood given [Volume]]:::Whole blood [Erythrocytes [#/volume] in Blood by Automated count]:::whole blood units given [Whole blood units given [#]]:::whole blood units [Whole blood units]:::HEMATOLOGY/CELL COUNTS [MCHC [Entitic Mass/volume] in Red Blood Cells by Automated count]:::Complete response [Complete response]:::Hematology and Cell counts [Hematology and Cell counts]:::Hemoglobin and Hematocrit panel [Hemoglobin and Hematocrit panel]:::Platelet count [Platelets [#/volume] in Blood by Automated count]:::hematocrit test status [Hematocrit test status CPHS]:::Hematocrit Test Status/Results [Hematocrit test status/results Set CPHS]:::Hematocrit [Hematocrit [Volume Fraction] adjusted to ideal blood volume by calculation]:::Hematocrit, Bone marrow [Hematocrit [Volume Fraction] of Bone marrow by calculation]:::complete blood count w reflex manual differential panel [CBC W Reflex Manual Differential panel - Blood]:::complete blood count w auto differential panel [CBC W Auto Differential panel - Blood]:::plateletocrit [Plateletcrit [Volume Fraction] in Blood]:::Hematocrit, Blood [Hematocrit [Volume Fraction] of Blood by Automated count]:::blood [Blood [Presence] in Urine by Visual] |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_loinc_augmented_pipeline_2_83|
+|Type:|pipeline|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Language:|en|
+|Size:|3.4 GB|
+
+## Included Models
+
+- DocumentAssembler
+- SentenceDetectorDLModel
+- TokenizerModel
+- WordEmbeddingsModel
+- MedicalNerModel
+- NerConverterInternalModel
+- MedicalNerModel
+- NerConverterInternalModel
+- ChunkMergeModel
+- Chunk2Doc
+- BertSentenceEmbeddings
+- SentenceEntityResolverModel

--- a/docs/_posts/ozgurcaglayan1981/2026-09-07-sbiobertresolve_loinc_numeric_augmented_pipeline_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-07-sbiobertresolve_loinc_numeric_augmented_pipeline_2_83_en.md
@@ -1,0 +1,112 @@
+---
+layout: model
+title: Pipeline for Logical Observation Identifiers Names and Codes (LOINC-Numeric) (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_loinc_numeric_augmented_pipeline_2_83
+date: 2026-09-07
+tags: [en, entity_resolution, licensed, clinical, loinc, pipeline, sbiobert]
+task: [Entity Resolution, Pipeline Healthcare]
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: PipelineModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This pipeline extracts `TEST` entities and maps them to their corresponding Logical Observation Identifiers Names and Codes (LOINC) codes using `sbiobert_base_cased_mli` sentence embeddings. It is trained on the augmented version of the LOINC 2.83 dataset (LOINC 2.83 official data plus an in-house curated dataset), scoped to numeric LOINC codes, without the inclusion of LOINC's non-numeric Part, Answer, Panel, Survey, and other auxiliary/document codes.
+
+If you also need LOINC's non-numeric auxiliary codes, use `sbiobertresolve_loinc_augmented_pipeline_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/07.0.Pretrained_Clinical_Pipelines.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_numeric_augmented_pipeline_2_83_en_6.4.1_3.4_1788739819841.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_numeric_augmented_pipeline_2_83_en_6.4.1_3.4_1788739819841.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+from sparknlp.pretrained import PretrainedPipeline
+
+loinc_pipeline = PretrainedPipeline("sbiobertresolve_loinc_numeric_augmented_pipeline_2_83", "en", "clinical/models")
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = loinc_pipeline.transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+from johnsnowlabs import nlp, medical
+
+loinc_pipeline = nlp.PretrainedPipeline("sbiobertresolve_loinc_numeric_augmented_pipeline_2_83", "en", "clinical/models")
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = loinc_pipeline.transform(data)
+
+```
+```scala
+
+import com.johnsnowlabs.nlp.pretrained.PretrainedPipeline
+
+val loinc_pipeline = PretrainedPipeline("sbiobertresolve_loinc_numeric_augmented_pipeline_2_83", "en", "clinical/models")
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val result = loinc_pipeline.transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| chunk                 | label   | loinc_code   | resolution                                                      | all_codes                                                                                                                                                                                              | all_resolutions                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|:----------------------|:--------|:-------------|:----------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| glucose               | Test    | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::74790-7:::51419-0:::81637-1:::47621-8:::32318-8:::104638-2:::50016-5:::72648-9:::27353-2:::6248-9:::41653-7:::4269-7:::95720-9:::41896-2:::26682-5:::50667-5:::97506-0:::80093-8:::20643-3    | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose HBT [Glucose challenge (hydrogen breath test) panel - Exhaled gas]:::Glucose cor [Sodium [Moles/volume] corrected for glucose in Serum or Plasma]:::Glucose correlation [Glucose meter to reference method correlation [Ratio] in Serum, Plasma or Blood by calculation]:::glucose.iv [Glucose.IV [Mass] of Dose]:::Glucose, Specimen [Glucose [Moles/volume] in Specimen]:::Glucose SD [Glucose standard deviation/Glucose mean in Reporting Period Interstitial fluid by calculation]:::sugar [Sugar [Type] of Dose]:::glucose gradient [Glucose in serum - glucose in synovial fluid [Molar concentration difference]]:::Glucose mean value [Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin]:::Gly [Soybean IgE Ab [Units/volume] in Serum]:::Glucomtr [Glucose [Mass/volume] in Capillary blood by Glucometer]:::glucose.po [Glucose.PO [Mass] of Dose]:::GlyR [Glycine receptor Ab [Titer] in Serum or Plasma by Immunoassay]:::Glucose Mtr Dev [Type of Glucose meter device]:::glycolate [Glycolate [Presence] in Urine]:::glucose tolerance [Glucose tolerance [Interpretation] in Serum or Plasma Narrative]:::Glucose management indicator [Glucose management indicator]:::glucosamine [Glucosamine [Moles/volume] in Serum or Plasma]:::Gln [Glutamine [Moles/volume] in Serum or Plasma]                                                                                                               |
+| hemoglobin A1c levels | Test    | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::43150-2:::4548-4:::10486-9:::21687-9:::112870-1:::51196-4:::4593-0:::10346-5:::50319-3:::17871-5:::50385-4:::6864-3:::72914-5:::14563-1:::96595-4:::2030-5:::2865-4                          | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hemoglobin A1c measurement device panel [Hemoglobin A1c measurement device panel]:::hemoglobin a1c/hemoglobin.total [Hemoglobin A1c/Hemoglobin.total in Blood]:::hemoglobin ag [Hemoglobin Ag [Presence] in Tissue by Immune stain]:::Hemoglobin, alpha 1 [HBA1 gene mutations found [Identifier] in Blood or Tissue by Targeted gene mutation analysis Nominal]:::hemoglobin a1c & estimated average glucose panel [Hemoglobin A1c and estimated average glucose panel - Blood]:::hemoglobin a1/hemoglobin.total [Hemoglobin A1/Hemoglobin.total in Blood by Electrophoresis]:::Hemoglobin I, Blood [Hemoglobin I [Presence] in Blood by Electrophoresis acid (pH 6.3)]:::hemoglobin a [Hemoglobin A [Units/volume] in Blood by Electrophoresis]:::hbme-1 ag [HBME-1 Ag [Presence] in Tissue by Immune stain]:::hemoglobin h [Hemoglobin H [Presence] in Blood by Heat denaturation]:::A1 Microglob [Alpha-1-Microglobulin.placental [Presence] in Vaginal fluid]:::hemoglobin s [Hemoglobin S [Presence] in Blood by Solubility test]:::hna 1c ab [HNA 1c Ab [Presence] in Serum by Immunoassay]:::hemoglobin^1st specimen [Hemoglobin [Presence] in Stool from gastrointestinal --1st specimen]:::Hemoglobin A1c/Hemoglobin.total in DBS [Hemoglobin A1c/Hemoglobin.total in DBS]:::CO Hemoglobin [Carboxyhemoglobin/Hemoglobin.total in Arterial blood]:::alpha 1 globulin [Alpha 1 globulin [Mass/volume] in Serum or Plasma by Electrophoresis] |
+| basic metabolic panel | Test    | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::101655-9:::89044-2:::9350-0:::50042-1:::79531-0:::43147-8:::24321-2:::79529-4:::104076-5:::79530-2:::112034-4:::81578-7:::1547-9:::107464-0:::41966-3                                        | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & hematocrit panel [Basic metabolic and hematocrit panel - Blood]:::basic metabolic & albumin panel [Basic metabolic and albumin panel - Serum or Plasma]:::Metabolic screen [Sulfhydryls [Presence] in Urine]:::Basal metabolic rate index [Basal metabolic rate index]:::basic mobility items [Basic mobility items number [Activity Measure for Post-Acute Care]]:::Metabolism measurement device panel [Metabolism measurement device panel]:::basic metabolic 2000 panel [Basic metabolic 2000 panel - Serum or Plasma]:::basic mobility score [Basic mobility score [AM-PAC]]:::basic metabolic & hemoglobin & hematocrit panel [Basic metabolic with hemoglobin and hematocrit panel - Blood]:::Basic mobility score SE [Basic mobility score standard error [AM-PAC]]:::Basic information [Basic information]:::PT Brain metabolic [PT Brain metabolic]:::glucose^baseline [Glucose [Mass/volume] in Serum or Plasma --baseline]:::metabolic disease screening [Metabolic disease screening Newborn]:::Name of Metabolism measurement device [Name of Metabolism measurement device]                                                                                                                                                                                                                                                                                                                                           |
+| sodium                | Test    | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::32340-2:::50912-5:::81011-9:::9086-0:::16527-4:::2950-4:::9087-8:::2954-6:::9485-4:::2957-9:::43423-3:::87451-1:::2955-3:::87452-9:::56979-8:::14055-8:::17796-4:::2948-8:::28003-2:::74993-7 | sodium [Sodium [Moles/volume] in Serum or Plasma]:::Sodium, Specimen [Sodium [Moles/volume] in Specimen]:::Sodium, Hair [Sodium [Moles/mass] in Hair]:::sodium intake [Sodium intake 24 hour Estimated]:::Sodium intake Est [Sodium intake Estimated]:::calcium/sodium [Calcium/Sodium [Mass Ratio] in Serum or Plasma]:::Sodium, Body fluid [Sodium [Moles/volume] in Body fluid]:::Sodium intake Measured [Sodium intake Measured]:::Sodium, Sweat [Sodium [Moles/volume] in Sweat]:::Sodium, Water [Sodium [Mass/volume] in Water]:::sodium renal clearance [Sodium renal clearance in 24 hour Urine and Serum or Plasma]:::sodium urate [Sodium urate [Saturation Fraction] in 24 hour Urine]:::Sodium [Mass/volume] in Specimen [Sodium [Mass/volume] in Specimen]:::Sodium, Urine [Sodium [Moles/volume] in Urine]:::Sodium [Mass/mass] in Specimen [Sodium [Mass/mass] in Specimen]:::Sodium, Saliva [Sodium [Moles/volume] in Saliva (oral fluid)]:::Sodium Stl-sCnt [Sodium [Moles/mass] in Stool]:::Sodium, Hyperal solution [Sodium [Moles/volume] in Hyperal solution]:::Sodium, Spinal fluid [Sodium [Moles/volume] in Cerebral spinal fluid]:::sodium/potassium [Sodium/Potassium [Molar ratio] in Serum or Plasma]:::Chloride+sodium Pnl [Chloride and sodium panel [Moles/volume] - Sweat]                                                                                                                                                                                                     |
+| potassium             | Test    | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::32336-0:::59733-6:::9073-8:::28003-2:::2821-7:::50902-6:::2830-8:::9074-6:::25506-7:::9482-1:::87455-2:::2819-1:::49788-3:::2827-4:::2828-2:::59010-9:::32713-0                     | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Potassium intake 24 hour]:::Potassium, Specimen [Potassium [Moles/volume] in Specimen]:::Potassium, Tissue [Potassium [Mass/mass] in Tissue]:::Potassium intake Est [Potassium intake Estimated]:::sodium/potassium [Sodium/Potassium [Molar ratio] in Serum or Plasma]:::Potassium, Body fluid [Potassium [Moles/volume] in Body fluid]:::Potassium, Hair [Potassium [Moles/mass] in Hair]:::potassium renal clearance [Potassium renal clearance in 24 hour Urine and Serum or Plasma]:::Potassium intake Measured [Potassium intake Measured]:::Potassium Stl-sCnt [Potassium [Moles/mass] in Stool]:::Potassium, Water [Potassium [Mass/volume] in Water]:::Potassium Spec-mCnt [Potassium [Mass/mass] in Specimen]:::Potassium, Spinal fluid [Potassium [Moles/volume] in Cerebral spinal fluid]:::Potassium Amn-sCnc [Potassium [Moles/volume] in Amniotic fluid]:::Potassium, Sweat [Potassium [Moles/volume] in Sweat]:::Potassium, Urine [Potassium [Moles/volume] in Urine]:::fractional excretion of potassium [Fractional excretion of potassium [Ratio] in Urine and Serum or Plasma collected for unspecified duration]:::Potassium BldA-sCnc [Potassium [Moles/volume] in Arterial blood]                                                                                                                                                                                                                           |
+| complete blood count  | Test    | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::74412-8:::47288-6:::1335-9:::789-8:::51876-1:::786-4:::777-3:::39227-4:::41986-1:::111539-3:::55781-9:::57022-6:::57021-8:::51637-7:::4544-3:::53963-5:::50774-9:::111533-6        | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood count panel [CBC panel - Blood by Automated count]:::complete blood count w differential panel [CBC W Differential panel - Cord blood]:::complete blood count wo differential panel [CBC WO Differential panel - Cord blood]:::whole blood given [Whole blood given [Volume]]:::Whole blood [Erythrocytes [#/volume] in Blood by Automated count]:::whole blood units given [Whole blood units given [#]]:::HEMATOLOGY/CELL COUNTS [MCHC [Entitic Mass/volume] in Red Blood Cells by Automated count]:::Platelet count [Platelets [#/volume] in Blood by Automated count]:::hematocrit test status [Hematocrit test status CPHS]:::Hematocrit Test Status/Results [Hematocrit test status/results Set CPHS]:::Hematocrit [Hematocrit [Volume Fraction] adjusted to ideal blood volume by calculation]:::Hematocrit, Bone marrow [Hematocrit [Volume Fraction] of Bone marrow by calculation]:::complete blood count w reflex manual differential panel [CBC W Reflex Manual Differential panel - Blood]:::complete blood count w auto differential panel [CBC W Auto Differential panel - Blood]:::plateletocrit [Plateletcrit [Volume Fraction] in Blood]:::Hematocrit, Blood [Hematocrit [Volume Fraction] of Blood by Automated count]:::blood [Blood [Presence] in Urine by Visual]:::Nucleated cells, Blood [Nucleated cells [#/volume] in Blood]:::specimen count [Specimen Count [#] by calculation]                   |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_loinc_numeric_augmented_pipeline_2_83|
+|Type:|pipeline|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Language:|en|
+|Size:|3.1 GB|
+
+## Included Models
+
+- DocumentAssembler
+- SentenceDetectorDLModel
+- TokenizerModel
+- WordEmbeddingsModel
+- MedicalNerModel
+- NerConverterInternalModel
+- MedicalNerModel
+- NerConverterInternalModel
+- ChunkMergeModel
+- Chunk2Doc
+- BertSentenceEmbeddings
+- SentenceEntityResolverModel

--- a/docs/_posts/ozgurcaglayan1981/2026-09-07-sbiobertresolve_loinc_numeric_pipeline_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-07-sbiobertresolve_loinc_numeric_pipeline_2_83_en.md
@@ -1,0 +1,114 @@
+---
+layout: model
+title: Pipeline for Logical Observation Identifiers Names and Codes (LOINC-Numeric) (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_loinc_numeric_pipeline_2_83
+date: 2026-09-07
+tags: [en, entity_resolution, licensed, clinical, loinc, pipeline, sbiobert]
+task: [Entity Resolution, Pipeline Healthcare]
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: PipelineModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This pipeline extracts `TEST` entities and maps them to their corresponding Logical Observation Identifiers Names and Codes (LOINC) codes using `sbiobert_base_cased_mli` sentence embeddings.
+
+Trained on the official LOINC 2.83 dataset, scoped to numeric LOINC codes, without the inclusion of LOINC "Document Ontology" codes starting with the letter "L".
+
+If you also need LOINC's non-numeric auxiliary codes (e.g. Part codes prefixed "LP"), use `sbiobertresolve_loinc_pipeline_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/07.0.Pretrained_Clinical_Pipelines.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_numeric_pipeline_2_83_en_6.4.1_3.4_1788740225697.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_numeric_pipeline_2_83_en_6.4.1_3.4_1788740225697.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+from sparknlp.pretrained import PretrainedPipeline
+
+loinc_pipeline = PretrainedPipeline("sbiobertresolve_loinc_numeric_pipeline_2_83", "en", "clinical/models")
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = loinc_pipeline.transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+from johnsnowlabs import nlp, medical
+
+loinc_pipeline = nlp.PretrainedPipeline("sbiobertresolve_loinc_numeric_pipeline_2_83", "en", "clinical/models")
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = loinc_pipeline.transform(data)
+
+```
+```scala
+
+import com.johnsnowlabs.nlp.pretrained.PretrainedPipeline
+
+val loinc_pipeline = PretrainedPipeline("sbiobertresolve_loinc_numeric_pipeline_2_83", "en", "clinical/models")
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val result = loinc_pipeline.transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| chunk                 | label   | loinc_code   | resolution                                                      | all_codes                                                                                                                                                                                                 | all_resolutions                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+|:----------------------|:--------|:-------------|:----------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| glucose               | Test    | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::74790-7:::51419-0:::81637-1:::47621-8:::104638-2:::50016-5:::72648-9:::27353-2:::6248-9:::41653-7:::4269-7:::95720-9:::41896-2:::26682-5:::50667-5:::97506-0:::80093-8:::20643-3                 | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose HBT [Glucose challenge (hydrogen breath test) panel - Exhaled gas]:::Glucose cor [Sodium [Moles/volume] corrected for glucose in Serum or Plasma]:::Glucose correlation [Glucose meter to reference method correlation [Ratio] in Serum, Plasma or Blood by calculation]:::glucose.iv [Glucose.IV [Mass] of Dose]:::Glucose SD [Glucose standard deviation/Glucose mean in Reporting Period Interstitial fluid by calculation]:::sugar [Sugar [Type] of Dose]:::glucose gradient [Glucose in serum - glucose in synovial fluid [Molar concentration difference]]:::Glucose mean value [Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin]:::Gly [Soybean IgE Ab [Units/volume] in Serum]:::Glucomtr [Glucose [Mass/volume] in Capillary blood by Glucometer]:::glucose.po [Glucose.PO [Mass] of Dose]:::GlyR [Glycine receptor Ab [Titer] in Serum or Plasma by Immunoassay]:::Glucose Mtr Dev [Type of Glucose meter device]:::glycolate [Glycolate [Presence] in Urine]:::glucose tolerance [Glucose tolerance [Interpretation] in Serum or Plasma Narrative]:::Glucose management indicator [Glucose management indicator]:::glucosamine [Glucosamine [Moles/volume] in Serum or Plasma]:::Gln [Glutamine [Moles/volume] in Serum or Plasma]                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| hemoglobin A1c levels | Test    | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::43150-2:::4548-4:::10486-9:::21687-9:::112870-1:::51196-4:::10346-5:::50319-3:::17871-5:::4593-0:::50385-4:::6864-3:::72914-5:::14563-1:::96595-4:::2030-5:::2865-4:::62854-5:::96496-5         | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::Hemoglobin A1c measurement device panel [Hemoglobin A1c measurement device panel]:::hemoglobin a1c/hemoglobin.total [Hemoglobin A1c/Hemoglobin.total in Blood]:::hemoglobin ag [Hemoglobin Ag [Presence] in Tissue by Immune stain]:::Hemoglobin, alpha 1 [HBA1 gene mutations found [Identifier] in Blood or Tissue by Targeted gene mutation analysis Nominal]:::hemoglobin a1c & estimated average glucose panel [Hemoglobin A1c and estimated average glucose panel - Blood]:::hemoglobin a1/hemoglobin.total [Hemoglobin A1/Hemoglobin.total in Blood by Electrophoresis]:::hemoglobin a [Hemoglobin A [Units/volume] in Blood by Electrophoresis]:::hbme-1 ag [HBME-1 Ag [Presence] in Tissue by Immune stain]:::hemoglobin h [Hemoglobin H [Presence] in Blood by Heat denaturation]:::hemoglobin i [Hemoglobin I [Presence] in Blood by Electrophoresis acid (pH 6.3)]:::A1 Microglob [Alpha-1-Microglobulin.placental [Presence] in Vaginal fluid]:::hemoglobin s [Hemoglobin S [Presence] in Blood by Solubility test]:::hna 1c ab [HNA 1c Ab [Presence] in Serum by Immunoassay]:::hemoglobin^1st specimen [Hemoglobin [Presence] in Stool from gastrointestinal --1st specimen]:::Hemoglobin A1c/Hemoglobin.total in DBS [Hemoglobin A1c/Hemoglobin.total in DBS]:::CO Hemoglobin [Carboxyhemoglobin/Hemoglobin.total in Arterial blood]:::alpha 1 globulin [Alpha 1 globulin [Mass/volume] in Serum or Plasma by Electrophoresis]:::Glycosylated hemoglobin assay [PhenX - glycosylated hemoglobin assay reflecting long-term glucose concentration protocol 140901]:::GlyRa-1 Ab [Glycine receptor alpha-1 subunit IgG Ab [Presence] in Serum by Cell binding immunofluorescent assay] |
+| basic metabolic panel | Test    | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::101655-9:::89044-2:::9350-0:::50042-1:::79531-0:::43147-8:::24321-2:::79529-4:::104076-5:::79530-2:::112034-4:::81578-7:::1547-9:::107464-0:::41966-3                                           | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & hematocrit panel [Basic metabolic and hematocrit panel - Blood]:::basic metabolic & albumin panel [Basic metabolic and albumin panel - Serum or Plasma]:::Metabolic screen [Sulfhydryls [Presence] in Urine]:::Basal metabolic rate index [Basal metabolic rate index]:::basic mobility items [Basic mobility items number [Activity Measure for Post-Acute Care]]:::Metabolism measurement device panel [Metabolism measurement device panel]:::basic metabolic 2000 panel [Basic metabolic 2000 panel - Serum or Plasma]:::basic mobility score [Basic mobility score [AM-PAC]]:::basic metabolic & hemoglobin & hematocrit panel [Basic metabolic with hemoglobin and hematocrit panel - Blood]:::Basic mobility score SE [Basic mobility score standard error [AM-PAC]]:::Basic information [Basic information]:::PT Brain metabolic [PT Brain metabolic]:::glucose^baseline [Glucose [Mass/volume] in Serum or Plasma --baseline]:::metabolic disease screening [Metabolic disease screening Newborn]:::Name of Metabolism measurement device [Name of Metabolism measurement device]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| sodium                | Test    | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::81011-9:::9086-0:::16527-4:::9087-8:::2957-9:::43423-3:::87451-1:::50912-5:::87452-9:::14055-8:::28003-2:::74993-7:::51205-3:::23611-7:::2954-6:::2950-4:::32340-2:::43223-7:::49135-7:::54437-9 | sodium [Sodium [Moles/volume] in Serum or Plasma]:::sodium intake [Sodium intake 24 hour Estimated]:::Sodium intake Est [Sodium intake Estimated]:::calcium/sodium [Calcium/Sodium [Mass Ratio] in Serum or Plasma]:::Sodium intake Measured [Sodium intake Measured]:::sodium renal clearance [Sodium renal clearance in 24 hour Urine and Serum or Plasma]:::sodium urate [Sodium urate [Saturation Fraction] in 24 hour Urine]:::Sodium [Mass/volume] in Specimen [Sodium [Mass/volume] in Specimen]:::Sodium Hair-sCnt [Sodium [Moles/mass] in Hair]:::Sodium [Mass/mass] in Specimen [Sodium [Mass/mass] in Specimen]:::Sodium Stl-sCnt [Sodium [Moles/mass] in Stool]:::sodium/potassium [Sodium/Potassium [Molar ratio] in Serum or Plasma]:::Chloride+sodium Pnl [Chloride and sodium panel [Moles/volume] - Sweat]:::Sodium Hair-mCnt [Sodium [Mass/mass] in Hair]:::Nemasol sodium [Para aminosalicylate [Susceptibility] by Method for Slow-growing mycobacteria]:::Sodium Sweat-sCnc [Sodium [Moles/volume] in Sweat]:::Sodium [Moles/volume] in Body fluid [Sodium [Moles/volume] in Body fluid]:::Sodium Spec-sCnc [Sodium [Moles/volume] in Specimen]:::Sodium/Creat Ur-Rto [Sodium/Creatinine [Ratio] in Urine]:::fractional excretion of sodium [Fractional excretion of sodium [Ratio] in Urine and Serum or Plasma]:::sodium urate/total [Sodium urate/Total in Stone by Infrared spectroscopy]                                                                                                                                                                                                                                                                                                                                            |
+| potassium             | Test    | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::9073-8:::28003-2:::2830-8:::59733-6:::9074-6:::25506-7:::87455-2:::50902-6:::32336-0:::49788-3:::59010-9:::32713-0:::79710-0:::87454-5:::9482-1:::12814-0:::2828-2:::34548-8:::6940-1  | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Potassium intake 24 hour]:::Potassium intake Est [Potassium intake Estimated]:::sodium/potassium [Sodium/Potassium [Molar ratio] in Serum or Plasma]:::potassium renal clearance [Potassium renal clearance in 24 hour Urine and Serum or Plasma]:::Potassium Tiss-mCnt [Potassium [Mass/mass] in Tissue]:::Potassium intake Measured [Potassium intake Measured]:::Potassium Stl-sCnt [Potassium [Moles/mass] in Stool]:::Potassium Spec-mCnt [Potassium [Mass/mass] in Specimen]:::Potassium Hair-sCnt [Potassium [Moles/mass] in Hair]:::Potassium Spec-sCnc [Potassium [Moles/volume] in Specimen]:::Potassium Amn-sCnc [Potassium [Moles/volume] in Amniotic fluid]:::fractional excretion of potassium [Fractional excretion of potassium [Ratio] in Urine and Serum or Plasma collected for unspecified duration]:::Potassium BldA-sCnc [Potassium [Moles/volume] in Arterial blood]:::Potassium Hair-mCnt [Potassium [Mass/mass] in Hair]:::Potassium [Mass/volume] in Specimen [Potassium [Mass/volume] in Specimen]:::Potassium Wat-mCnc [Potassium [Mass/volume] in Water]:::Potassium Vitf-sCnc [Potassium [Moles/volume] in Vitreous fluid]:::Potassium Ur-sCnc [Potassium [Moles/volume] in Urine]:::Sodium + Potassium Pnl [Sodium and Potassium panel [Moles/volume] - Serum or Plasma]:::Potassium ?Tm Stl-sRate [Potassium [Moles/time] in unspecified time Stool]                                                                                                                                                                                                                                                                                              |
+| complete blood count  | Test    | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::74412-8:::47288-6:::1335-9:::789-8:::51876-1:::786-4:::777-3:::39227-4:::41986-1:::57022-6:::57021-8:::51637-7:::53963-5:::111533-6:::34556-1:::24360-0:::91604-9:::43113-0           | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood count panel [CBC panel - Blood by Automated count]:::complete blood count w differential panel [CBC W Differential panel - Cord blood]:::complete blood count wo differential panel [CBC WO Differential panel - Cord blood]:::whole blood given [Whole blood given [Volume]]:::Whole blood [Erythrocytes [#/volume] in Blood by Automated count]:::whole blood units given [Whole blood units given [#]]:::HEMATOLOGY/CELL COUNTS [MCHC [Entitic Mass/volume] in Red Blood Cells by Automated count]:::Platelet count [Platelets [#/volume] in Blood by Automated count]:::hematocrit test status [Hematocrit test status CPHS]:::Hematocrit Test Status/Results [Hematocrit test status/results Set CPHS]:::complete blood count w reflex manual differential panel [CBC W Reflex Manual Differential panel - Blood]:::complete blood count w auto differential panel [CBC W Auto Differential panel - Blood]:::plateletocrit [Plateletcrit [Volume Fraction] in Blood]:::blood [Blood [Presence] in Urine by Visual]:::specimen count [Specimen Count [#] by calculation]:::Cell count panel - Body fluid [Cell count panel - Body fluid]:::hemoglobin & hematocrit panel [Hemoglobin and Hematocrit panel - Blood]:::Device count [Device count]:::hemoglobin panel [Hemoglobin electrophoresis panel in Blood]                                                                                                                                                                                                                                                                                                                                                          |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_loinc_numeric_pipeline_2_83|
+|Type:|pipeline|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Language:|en|
+|Size:|3.0 GB|
+
+## Included Models
+
+- DocumentAssembler
+- SentenceDetectorDLModel
+- TokenizerModel
+- WordEmbeddingsModel
+- MedicalNerModel
+- NerConverterInternalModel
+- MedicalNerModel
+- NerConverterInternalModel
+- ChunkMergeModel
+- Chunk2Doc
+- BertSentenceEmbeddings
+- SentenceEntityResolverModel

--- a/docs/_posts/ozgurcaglayan1981/2026-09-07-sbiobertresolve_loinc_pipeline_2_83_en.md
+++ b/docs/_posts/ozgurcaglayan1981/2026-09-07-sbiobertresolve_loinc_pipeline_2_83_en.md
@@ -1,0 +1,114 @@
+---
+layout: model
+title: Pipeline for Logical Observation Identifiers Names and Codes (LOINC) (sbiobert_base_cased_mli_onnx embeddings)
+author: John Snow Labs
+name: sbiobertresolve_loinc_pipeline_2_83
+date: 2026-09-07
+tags: [en, entity_resolution, licensed, clinical, loinc, pipeline, sbiobert]
+task: [Entity Resolution, Pipeline Healthcare]
+language: en
+edition: Healthcare NLP 6.4.1
+spark_version: 3.4
+supported: true
+annotator: PipelineModel
+article_header:
+  type: cover
+use_language_switcher: "Python-Scala-Java"
+---
+
+## Description
+
+This pipeline extracts `Test` entities from clinical texts and maps them to their corresponding Logical Observation Identifiers Names and Codes (LOINC) codes using `sbiobert_base_cased_mli` Sentence Bert Embeddings.
+
+Trained on the official LOINC 2.83 dataset.
+
+This pipeline may also resolve to non-numeric LOINC codes, including LOINC's own internal Part codes (prefixed "LP"). If you only need numeric, directly orderable/reportable LOINC codes, use `sbiobertresolve_loinc_numeric_pipeline_2_83` instead.
+
+It also provides the official resolution of the codes within the brackets.
+
+{:.btn-box}
+[Live Demo](https://nlp.johnsnowlabs.com/resolve_entities_codes){:.button.button-orange}
+[Open in Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/07.0.Pretrained_Clinical_Pipelines.ipynb){:.button.button-orange.button-orange-trans.co.button-icon}
+[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_pipeline_2_83_en_6.4.1_3.4_1788739958982.zip){:.button.button-orange.button-orange-trans.arr.button-icon.hidden}
+[Copy S3 URI](s3://auxdata.johnsnowlabs.com/clinical/models/sbiobertresolve_loinc_pipeline_2_83_en_6.4.1_3.4_1788739958982.zip){:.button.button-orange.button-orange-trans.button-icon.button-copy-s3}
+
+## How to use
+
+
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPythonNLU.html %}
+```python
+
+from sparknlp.pretrained import PretrainedPipeline
+
+loinc_pipeline = PretrainedPipeline("sbiobertresolve_loinc_pipeline_2_83", "en", "clinical/models")
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = loinc_pipeline.transform(data)
+
+```
+
+{:.jsl-block}
+```python
+
+from johnsnowlabs import nlp, medical
+
+loinc_pipeline = nlp.PretrainedPipeline("sbiobertresolve_loinc_pipeline_2_83", "en", "clinical/models")
+
+data = spark.createDataFrame([["The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count."]]).toDF("text")
+result = loinc_pipeline.transform(data)
+
+```
+```scala
+
+import com.johnsnowlabs.nlp.pretrained.PretrainedPipeline
+
+val loinc_pipeline = PretrainedPipeline("sbiobertresolve_loinc_pipeline_2_83", "en", "clinical/models")
+
+val data = Seq("The patient's glucose and hemoglobin A1c levels were checked, along with a basic metabolic panel including sodium and potassium, and a complete blood count.").toDF("text")
+val result = loinc_pipeline.transform(data)
+
+```
+</div>
+
+## Results
+
+```bash
+| chunk                 | label   | loinc_code   | resolution                                                      | all_codes                                                                                                                                                                                                            | all_resolutions                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|:----------------------|:--------|:-------------|:----------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| glucose               | Test    | 2345-7       | glucose [Glucose [Mass/volume] in Serum or Plasma]              | 2345-7:::74790-7:::51419-0:::81637-1:::47621-8:::104638-2:::50016-5:::72648-9:::27353-2:::6248-9:::41653-7:::LP69206-8:::4269-7:::95720-9:::41896-2:::26682-5:::50667-5:::97506-0:::80093-8:::20643-3                | glucose [Glucose [Mass/volume] in Serum or Plasma]:::Glucose HBT [Glucose challenge (hydrogen breath test) panel - Exhaled gas]:::Glucose cor [Sodium [Moles/volume] corrected for glucose in Serum or Plasma]:::Glucose correlation [Glucose meter to reference method correlation [Ratio] in Serum, Plasma or Blood by calculation]:::glucose.iv [Glucose.IV [Mass] of Dose]:::Glucose SD [Glucose standard deviation/Glucose mean in Reporting Period Interstitial fluid by calculation]:::sugar [Sugar [Type] of Dose]:::glucose gradient [Glucose in serum - glucose in synovial fluid [Molar concentration difference]]:::Glucose mean value [Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin]:::Gly [Soybean IgE Ab [Units/volume] in Serum]:::Glucomtr [Glucose [Mass/volume] in Capillary blood by Glucometer]:::glucose csf [Glucose in CSF]:::glucose.po [Glucose.PO [Mass] of Dose]:::GlyR [Glycine receptor Ab [Titer] in Serum or Plasma by Immunoassay]:::Glucose Mtr Dev [Type of Glucose meter device]:::glycolate [Glycolate [Presence] in Urine]:::glucose tolerance [Glucose tolerance [Interpretation] in Serum or Plasma Narrative]:::Glucose management indicator [Glucose management indicator]:::glucosamine [Glucosamine [Moles/volume] in Serum or Plasma]:::Gln [Glutamine [Moles/volume] in Serum or Plasma]                                                                                                                                                                            |
+| hemoglobin A1c levels | Test    | 41995-2      | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]          | 41995-2:::LP16412-6:::43150-2:::4548-4:::10486-9:::21687-9:::112870-1:::LP16430-8:::51196-4:::10346-5:::50319-3:::17871-5:::4593-0:::LP94632-4:::50385-4:::6864-3:::72914-5:::LP94633-2:::14563-1:::96595-4:::2030-5 | hemoglobin a1c [Hemoglobin A1c [Mass/volume] in Blood]:::hemoglobin a1 [Hemoglobin A1]:::Hemoglobin A1c measurement device panel [Hemoglobin A1c measurement device panel]:::hemoglobin a1c/hemoglobin.total [Hemoglobin A1c/Hemoglobin.total in Blood]:::hemoglobin ag [Hemoglobin Ag [Presence] in Tissue by Immune stain]:::Hemoglobin, alpha 1 [HBA1 gene mutations found [Identifier] in Blood or Tissue by Targeted gene mutation analysis Nominal]:::hemoglobin a1c & estimated average glucose panel [Hemoglobin A1c and estimated average glucose panel - Blood]:::hemoglobin f1 [Hemoglobin F1]:::hemoglobin a1/hemoglobin.total [Hemoglobin A1/Hemoglobin.total in Blood by Electrophoresis]:::hemoglobin a [Hemoglobin A [Units/volume] in Blood by Electrophoresis]:::hbme-1 ag [HBME-1 Ag [Presence] in Tissue by Immune stain]:::hemoglobin h [Hemoglobin H [Presence] in Blood by Heat denaturation]:::hemoglobin i [Hemoglobin I [Presence] in Blood by Electrophoresis acid (pH 6.3)]:::hemoglobin d+g [Hemoglobin D+G]:::A1 Microglob [Alpha-1-Microglobulin.placental [Presence] in Vaginal fluid]:::hemoglobin s [Hemoglobin S [Presence] in Blood by Solubility test]:::hna 1c ab [HNA 1c Ab [Presence] in Serum by Immunoassay]:::hemoglobin n+i [Hemoglobin N+I]:::hemoglobin^1st specimen [Hemoglobin [Presence] in Stool from gastrointestinal --1st specimen]:::Hemoglobin A1c/Hemoglobin.total in DBS [Hemoglobin A1c/Hemoglobin.total in DBS]:::CO Hemoglobin [Carboxyhemoglobin/Hemoglobin.total in Arterial blood] |
+| basic metabolic panel | Test    | 51990-0      | basic metabolic panel [Basic metabolic panel - Blood]           | 51990-0:::101655-9:::89044-2:::9350-0:::50042-1:::79531-0:::43147-8:::24321-2:::79529-4:::104076-5:::79530-2:::112034-4:::81578-7:::LP76085-7:::LP35945-2:::1547-9:::107464-0:::41966-3                              | basic metabolic panel [Basic metabolic panel - Blood]:::basic metabolic & hematocrit panel [Basic metabolic and hematocrit panel - Blood]:::basic metabolic & albumin panel [Basic metabolic and albumin panel - Serum or Plasma]:::Metabolic screen [Sulfhydryls [Presence] in Urine]:::Basal metabolic rate index [Basal metabolic rate index]:::basic mobility items [Basic mobility items number [Activity Measure for Post-Acute Care]]:::Metabolism measurement device panel [Metabolism measurement device panel]:::basic metabolic 2000 panel [Basic metabolic 2000 panel - Serum or Plasma]:::basic mobility score [Basic mobility score [AM-PAC]]:::basic metabolic & hemoglobin & hematocrit panel [Basic metabolic with hemoglobin and hematocrit panel - Blood]:::Basic mobility score SE [Basic mobility score standard error [AM-PAC]]:::Basic information [Basic information]:::PT Brain metabolic [PT Brain metabolic]:::mds.basic [MDS.basic]:::metabolism measurement device [Metabolism measurement device]:::glucose^baseline [Glucose [Mass/volume] in Serum or Plasma --baseline]:::metabolic disease screening [Metabolic disease screening Newborn]:::Name of Metabolism measurement device [Name of Metabolism measurement device]                                                                                                                                                                                                                                                                                      |
+| sodium                | Test    | 2951-2       | sodium [Sodium [Moles/volume] in Serum or Plasma]               | 2951-2:::81011-9:::9086-0:::16527-4:::9087-8:::2957-9:::43423-3:::87451-1:::50912-5:::87452-9:::14055-8:::28003-2:::74993-7:::51205-3:::23611-7:::2954-6:::2950-4:::32340-2:::43223-7:::49135-7:::54437-9            | sodium [Sodium [Moles/volume] in Serum or Plasma]:::sodium intake [Sodium intake 24 hour Estimated]:::Sodium intake Est [Sodium intake Estimated]:::calcium/sodium [Calcium/Sodium [Mass Ratio] in Serum or Plasma]:::Sodium intake Measured [Sodium intake Measured]:::sodium renal clearance [Sodium renal clearance in 24 hour Urine and Serum or Plasma]:::sodium urate [Sodium urate [Saturation Fraction] in 24 hour Urine]:::Sodium [Mass/volume] in Specimen [Sodium [Mass/volume] in Specimen]:::Sodium Hair-sCnt [Sodium [Moles/mass] in Hair]:::Sodium [Mass/mass] in Specimen [Sodium [Mass/mass] in Specimen]:::Sodium Stl-sCnt [Sodium [Moles/mass] in Stool]:::sodium/potassium [Sodium/Potassium [Molar ratio] in Serum or Plasma]:::Chloride+sodium Pnl [Chloride and sodium panel [Moles/volume] - Sweat]:::Sodium Hair-mCnt [Sodium [Mass/mass] in Hair]:::Nemasol sodium [Para aminosalicylate [Susceptibility] by Method for Slow-growing mycobacteria]:::Sodium Sweat-sCnc [Sodium [Moles/volume] in Sweat]:::Sodium [Moles/volume] in Body fluid [Sodium [Moles/volume] in Body fluid]:::Sodium Spec-sCnc [Sodium [Moles/volume] in Specimen]:::Sodium/Creat Ur-Rto [Sodium/Creatinine [Ratio] in Urine]:::fractional excretion of sodium [Fractional excretion of sodium [Ratio] in Urine and Serum or Plasma]:::sodium urate/total [Sodium urate/Total in Stone by Infrared spectroscopy]                                                                                                                                |
+| potassium             | Test    | 2823-3       | potassium [Potassium [Moles/volume] in Serum or Plasma]         | 2823-3:::10322-6:::9073-8:::28003-2:::2830-8:::59733-6:::9074-6:::25506-7:::87455-2:::50902-6:::32336-0:::49788-3:::59010-9:::32713-0:::79710-0:::87454-5:::9482-1:::12814-0:::2828-2:::34548-8:::6940-1             | potassium [Potassium [Moles/volume] in Serum or Plasma]:::potassium intake [Potassium intake 24 hour]:::Potassium intake Est [Potassium intake Estimated]:::sodium/potassium [Sodium/Potassium [Molar ratio] in Serum or Plasma]:::potassium renal clearance [Potassium renal clearance in 24 hour Urine and Serum or Plasma]:::Potassium Tiss-mCnt [Potassium [Mass/mass] in Tissue]:::Potassium intake Measured [Potassium intake Measured]:::Potassium Stl-sCnt [Potassium [Moles/mass] in Stool]:::Potassium Spec-mCnt [Potassium [Mass/mass] in Specimen]:::Potassium Hair-sCnt [Potassium [Moles/mass] in Hair]:::Potassium Spec-sCnc [Potassium [Moles/volume] in Specimen]:::Potassium Amn-sCnc [Potassium [Moles/volume] in Amniotic fluid]:::fractional excretion of potassium [Fractional excretion of potassium [Ratio] in Urine and Serum or Plasma collected for unspecified duration]:::Potassium BldA-sCnc [Potassium [Moles/volume] in Arterial blood]:::Potassium Hair-mCnt [Potassium [Mass/mass] in Hair]:::Potassium [Mass/volume] in Specimen [Potassium [Mass/volume] in Specimen]:::Potassium Wat-mCnc [Potassium [Mass/volume] in Water]:::Potassium Vitf-sCnc [Potassium [Moles/volume] in Vitreous fluid]:::Potassium Ur-sCnc [Potassium [Moles/volume] in Urine]:::Sodium + Potassium Pnl [Sodium and Potassium panel [Moles/volume] - Serum or Plasma]:::Potassium ?Tm Stl-sRate [Potassium [Moles/time] in unspecified time Stool]                                                                                  |
+| complete blood count  | Test    | 24358-4      | Complete Blood Count [Hemogram without Platelets panel - Blood] | 24358-4:::58410-2:::74412-8:::47288-6:::1335-9:::789-8:::51876-1:::LP71083-7:::786-4:::777-3:::39227-4:::41986-1:::LP15101-6:::57022-6:::57021-8:::51637-7:::53963-5:::111533-6:::34556-1:::24360-0                  | Complete Blood Count [Hemogram without Platelets panel - Blood]:::complete blood count panel [CBC panel - Blood by Automated count]:::complete blood count w differential panel [CBC W Differential panel - Cord blood]:::complete blood count wo differential panel [CBC WO Differential panel - Cord blood]:::whole blood given [Whole blood given [Volume]]:::Whole blood [Erythrocytes [#/volume] in Blood by Automated count]:::whole blood units given [Whole blood units given [#]]:::whole blood units [Whole blood units]:::HEMATOLOGY/CELL COUNTS [MCHC [Entitic Mass/volume] in Red Blood Cells by Automated count]:::Platelet count [Platelets [#/volume] in Blood by Automated count]:::hematocrit test status [Hematocrit test status CPHS]:::Hematocrit Test Status/Results [Hematocrit test status/results Set CPHS]:::hematocrit [Hematocrit]:::complete blood count w reflex manual differential panel [CBC W Reflex Manual Differential panel - Blood]:::complete blood count w auto differential panel [CBC W Auto Differential panel - Blood]:::plateletocrit [Plateletcrit [Volume Fraction] in Blood]:::blood [Blood [Presence] in Urine by Visual]:::specimen count [Specimen Count [#] by calculation]:::Cell count panel - Body fluid [Cell count panel - Body fluid]:::hemoglobin & hematocrit panel [Hemoglobin and Hematocrit panel - Blood]                                                                                                                                                                         |
+```
+
+{:.model-param}
+## Model Information
+
+{:.table-model}
+|---|---|
+|Model Name:|sbiobertresolve_loinc_pipeline_2_83|
+|Type:|pipeline|
+|Compatibility:|Healthcare NLP 6.4.1+|
+|License:|Licensed|
+|Edition:|Official|
+|Language:|en|
+|Size:|3.0 GB|
+
+## Included Models
+
+- DocumentAssembler
+- SentenceDetectorDLModel
+- TokenizerModel
+- WordEmbeddingsModel
+- MedicalNerModel
+- NerConverterInternalModel
+- MedicalNerModel
+- NerConverterInternalModel
+- ChunkMergeModel
+- Chunk2Doc
+- BertSentenceEmbeddings
+- SentenceEntityResolverModel


### PR DESCRIPTION
# LOINC 2.83 — Resolver & Mapper Update

Adds/updates 12 resolvers, 2 mappers, and 4 pretrained pipelines for Logical Observation
Identifiers Names and Codes (LOINC), release 2.83 (4 training corpora — plain and augmented,
each split into numeric-only and full including non-numeric Part/Answer/Panel/Survey codes).

## Models
| Model | Type | Embedding | Status |
|---|---|---|---|
| `sbiobertresolve_loinc_2_83` | Sentence Entity Resolver | `sbiobert_base_cased_mli_onnx` | Updated |
| `biolordresolve_loinc_2_83` | Sentence Entity Resolver | `mpnet_embeddings_biolord_2023_c` | New |
| `bgeresolve_loinc_2_83` | Sentence Entity Resolver | `bge_base_en_v1_5_onnx` | New |
| `sbiobertresolve_loinc_augmented_2_83` | Sentence Entity Resolver | `sbiobert_base_cased_mli_onnx` | Updated |
| `biolordresolve_loinc_augmented_2_83` | Sentence Entity Resolver | `mpnet_embeddings_biolord_2023_c` | Updated |
| `bgeresolve_loinc_augmented_2_83` | Sentence Entity Resolver | `bge_base_en_v1_5_onnx` | New |
| `sbiobertresolve_loinc_numeric_augmented_2_83` | Sentence Entity Resolver | `sbiobert_base_cased_mli_onnx` | Updated |
| `biolordresolve_loinc_numeric_augmented_2_83` | Sentence Entity Resolver | `mpnet_embeddings_biolord_2023_c` | New |
| `bgeresolve_loinc_numeric_augmented_2_83` | Sentence Entity Resolver | `bge_base_en_v1_5_onnx` | New |
| `sbiobertresolve_loinc_numeric_2_83` | Sentence Entity Resolver | `sbiobert_base_cased_mli_onnx` | Updated |
| `biolordresolve_loinc_numeric_2_83` | Sentence Entity Resolver | `mpnet_embeddings_biolord_2023_c` | New |
| `bgeresolve_loinc_numeric_2_83` | Sentence Entity Resolver | `bge_base_en_v1_5_onnx` | New |
| `loinc_mapper_2_83` | Chunk Mapper | — | New |
| `loinc_numeric_mapper_2_83` | Chunk Mapper | — | New |
| `sbiobertresolve_loinc_pipeline_2_83` | Pretrained Pipeline | `sbiobert_base_cased_mli_onnx` | New |
| `sbiobertresolve_loinc_augmented_pipeline_2_83` | Pretrained Pipeline | `sbiobert_base_cased_mli_onnx` | Updated — renamed from `loinc_resolver_pipeline` |
| `sbiobertresolve_loinc_numeric_pipeline_2_83` | Pretrained Pipeline | `sbiobert_base_cased_mli_onnx` | New |
| `sbiobertresolve_loinc_numeric_augmented_pipeline_2_83` | Pretrained Pipeline | `sbiobert_base_cased_mli_onnx` | Updated — renamed from `loinc_numeric_resolver_pipeline` |

## Data
Trained on the official LOINC 2.83 dataset, release 2.83.
